### PR TITLE
Bug fixes/voicemail in millis

### DIFF
--- a/src/domain/Voicemail.js
+++ b/src/domain/Voicemail.js
@@ -23,9 +23,9 @@ type Response = {
 };
 
 type VoicemailArguments = {
-  id?: string,
-  date?: Date,
-  duration?: number,
+  id: string,
+  date: Date,
+  duration: number,
   caller: {
     name: string,
     number: string
@@ -34,9 +34,9 @@ type VoicemailArguments = {
 };
 
 export default class Voicemail {
-  id: ?string;
-  date: ?Date;
-  duration: ?number;
+  id: string;
+  date: Date;
+  duration: number;
   unread: ?boolean;
   caller: {
     name: string,

--- a/src/domain/Voicemail.js
+++ b/src/domain/Voicemail.js
@@ -6,7 +6,7 @@ type MessageResponse = {
   caller_id_num: string,
   duration: number,
   id: string,
-  folder: Object,
+  folder?: Object,
   timestamp: number
 };
 
@@ -46,7 +46,7 @@ export default class Voicemail {
   static parse(plain: MessageResponse): Voicemail {
     return new Voicemail({
       id: plain.id,
-      date: new Date(plain.timestamp),
+      date: new Date(plain.timestamp * 1000),
       duration: plain.duration * 1000,
       caller: {
         name: plain.caller_id_name,

--- a/src/domain/__tests__/Voicemail.test.js
+++ b/src/domain/__tests__/Voicemail.test.js
@@ -9,49 +9,58 @@ const defaultCaller = {
 
 describe('Voicemail', () => {
   it('is the same voicemail given the same id', () => {
-    const voicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller });
-    const anotherVoicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller });
+    const voicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller, date: new Date(), duration: 0 });
+    const anotherVoicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller, date: new Date(), duration: 0 });
 
     expect(voicemail.is(anotherVoicemail)).toBeTruthy();
   });
 
   it('is not the same voicemail given different ids', () => {
-    const voicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller });
-    const anotherVoicemail = new Voicemail({ id: 'ref-123', caller: defaultCaller });
+    const voicemail = new Voicemail({ id: 'ref-abc', caller: defaultCaller, date: new Date(), duration: 0 });
+    const anotherVoicemail = new Voicemail({ id: 'ref-123', caller: defaultCaller, date: new Date(), duration: 0 });
 
     expect(voicemail.is(anotherVoicemail)).toBeFalsy();
   });
 
-  it("matches when the query includes the caller's name", () => {
+  it('matches when the query includes the caller\'s name', () => {
     const voicemail = new Voicemail({
       caller: {
         name: 'john doe',
         number: '0101010101'
-      }
+      },
+      date: new Date(),
+      duration: 0,
+      id: 'ref-1234',
     });
     const query = 'john';
 
     expect(voicemail.contains(query)).toBeTruthy();
   });
 
-  it("matches when the query includes the uppercased caller's name", () => {
+  it('matches when the query includes the uppercased caller\'s name', () => {
     const voicemail = new Voicemail({
       caller: {
         name: 'John Doe',
         number: '0101010101'
-      }
+      },
+      date: new Date(),
+      duration: 0,
+      id: 'ref-1234',
     });
     const query = 'jOHn';
 
     expect(voicemail.contains(query)).toBeTruthy();
   });
 
-  it("matches when the query includes the caller's number", () => {
+  it('matches when the query includes the caller\'s number', () => {
     const voicemail = new Voicemail({
       caller: {
         name: 'john doe',
         number: '0101010101'
-      }
+      },
+      date: new Date(),
+      duration: 0,
+      id: 'ref-1234',
     });
     const query = '010101';
 
@@ -70,7 +79,7 @@ describe('Voicemail', () => {
 
       const voicemail = Voicemail.parse(raw);
 
-      expect(voicemail.date).toEqual(new Date(2018, 6, 5, 16, 36, 57));
+      expect(voicemail.date.toISOString()).toBe('2018-07-05T20:36:57.000Z');
     });
   });
 });

--- a/src/domain/__tests__/Voicemail.test.js
+++ b/src/domain/__tests__/Voicemail.test.js
@@ -62,7 +62,7 @@ describe('Voicemail', () => {
     it('can convert the date to unix timestamp', () => {
       const raw = {
         duration: 5,
-        timestamp: 1530823017,
+        timestamp: 1530823017, // Thu Jul 05 2018 16:36:57 GMT-0400 (GMT-04:00)
         id: "1530823017-00000000",
         caller_id_name: "Cl\u00e9ment Bourgeois",
         caller_id_num: "8005",
@@ -70,7 +70,6 @@ describe('Voicemail', () => {
 
       const voicemail = Voicemail.parse(raw);
 
-      // Thu Jul 05 2018 16:36:57 GMT-0400 (GMT-04:00)
       expect(voicemail.date).toEqual(new Date(2018, 6, 5, 16, 36, 57));
     });
   });

--- a/src/domain/__tests__/Voicemail.test.js
+++ b/src/domain/__tests__/Voicemail.test.js
@@ -57,4 +57,21 @@ describe('Voicemail', () => {
 
     expect(voicemail.contains(query)).toBeTruthy();
   });
+
+  describe('when parsing', () => {
+    it('can convert the date to unix timestamp', () => {
+      const raw = {
+        duration: 5,
+        timestamp: 1530823017,
+        id: "1530823017-00000000",
+        caller_id_name: "Cl\u00e9ment Bourgeois",
+        caller_id_num: "8005",
+      };
+
+      const voicemail = Voicemail.parse(raw);
+
+      // Thu Jul 05 2018 16:36:57 GMT-0400 (GMT-04:00)
+      expect(voicemail.date).toEqual(new Date(2018, 6, 5, 16, 36, 57));
+    });
+  });
 });


### PR DESCRIPTION
The backend return `timestamp: 1530823017` for example, and it is actually a unix timestamp. The expected value is `// Thu Jul 05 2018 16:36:57 GMT-0400 (GMT-04:00)`, but without the fix it returns `Jan 17 1980`