### PR TITLE
WIP: Update webrtc-adapter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-fetch": "^2.2.0",
     "reconnecting-websocket": "^4.1.10",
     "sip.js": "0.11.6",
-    "webrtc-adapter": "^6.4.4"
+    "webrtc-adapter": "7.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7960,10 +7960,10 @@ rsvp@^3.3.3:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
-rtcpeerconnection-shim@^1.2.14:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.14.tgz#67903d6f7b7bf508d6d1e4791de3e3b49c3754c0"
-  integrity sha512-/sl1vgarkFPU2rbXy+EMmytMQIzCKNbIm3fChjPnsdytKAROgoivB0KLE7PQRjKx/d/nr/Yx+6qu0/eCpoxn/A==
+rtcpeerconnection-shim@^1.2.15:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz#e7cc189a81b435324c4949aa3dfb51888684b243"
+  integrity sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==
   dependencies:
     sdp "^2.6.0"
 
@@ -9433,12 +9433,12 @@ webpack@^4.23.1:
     watchpack "^1.5.0"
     webpack-sources "^1.3.0"
 
-webrtc-adapter@^6.4.4:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-6.4.4.tgz#a1e54cc2765c57976d3d682a0de15110b91115d7"
-  integrity sha512-VNXpC9UTbNovaiPqEtUmMuBolo4K6V4qgYnoMl3i0q9LnXTGaFeyIQiFiLp5qoKJJGW3EJSLFX6qYDlgU6k4pg==
+webrtc-adapter@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/webrtc-adapter/-/webrtc-adapter-7.2.0.tgz#5b234a30a6dc507f2b1c3fab1cf2ced4b98b363e"
+  integrity sha512-+QsCKlCTjLVKKhkClQwXXgalyehiIzYcwKL7X2bS8cE/1paG44P8kW3kXOGMDJVy/1rnYMRz1ukYmobmGRw+4w==
   dependencies:
-    rtcpeerconnection-shim "^1.2.14"
+    rtcpeerconnection-shim "^1.2.15"
     sdp "^2.9.0"
 
 websocket-driver@>=0.5.1:


### PR DESCRIPTION
La version présente de webrtc-adapter laisse des exceptions dans les nouvelles de chrome (https://github.com/webrtcHacks/adapter/issues/874)

WIP, étant donné que le checkbuild ne marche pas, mais le SDK semble tout de même fonctionner (tout les tests dans le desktop passent)