### PR TITLE
add support for phone number without country code

### DIFF
--- a/src/utils/PhoneNumberUtil.js
+++ b/src/utils/PhoneNumberUtil.js
@@ -36,7 +36,20 @@ const getDisplayableNumber = (number: string, country: string, asYouType: boolea
   return displayValue;
 };
 
-const getCallableNumber = (number: string, country: string): string =>
-  getDisplayableNumber(number, country).replace(EXTRA_CHAR_REGEXP, '');
+const parsePhoneNumber = (phoneNumber: string): string => phoneNumber.replace(/[^+\d]/g, '');
 
-export { PhoneNumberUtil, PhoneNumberFormat, AsYouTypeFormatter, getDisplayableNumber, getCallableNumber };
+const getCallableNumber = (number: string, country: ?string): string => {
+  if (country) {
+    return getDisplayableNumber(number, country).replace(EXTRA_CHAR_REGEXP, '');
+  }
+  return parsePhoneNumber(number);
+};
+
+export {
+  PhoneNumberUtil,
+  PhoneNumberFormat,
+  parsePhoneNumber,
+  AsYouTypeFormatter,
+  getDisplayableNumber,
+  getCallableNumber
+};

--- a/src/utils/PhoneNumberUtil.js
+++ b/src/utils/PhoneNumberUtil.js
@@ -5,7 +5,7 @@ const PhoneNumberUtil = LibPhoneNumber.PhoneNumberUtil.getInstance();
 const { PhoneNumberFormat, AsYouTypeFormatter } = LibPhoneNumber;
 
 // eslint-disable-next-line
-const EXTRA_CHAR_REGEXP = /\(|\)|\-|\s/g;
+const EXTRA_CHAR_REGEXP = /[^+\d]/g;
 
 const shouldBeFormatted = (number: ?string) => {
   if (!number || number.length <= 5) {
@@ -36,7 +36,7 @@ const getDisplayableNumber = (number: string, country: string, asYouType: boolea
   return displayValue;
 };
 
-const parsePhoneNumber = (phoneNumber: string): string => phoneNumber.replace(/[^+\d]/g, '');
+const parsePhoneNumber = (phoneNumber: string): string => phoneNumber.replace(EXTRA_CHAR_REGEXP, '');
 
 const getCallableNumber = (number: string, country: ?string): string => {
   if (country) {

--- a/src/utils/__tests__/PhoneNumberUtil.test.js
+++ b/src/utils/__tests__/PhoneNumberUtil.test.js
@@ -28,9 +28,13 @@ describe('getCallableNumber', () => {
     expect(getCallableNumber('06 75 45 12 34', 'FR')).toBe('0675451234');
     expect(getCallableNumber('+1-202-555-0147', 'US')).toBe('2025550147');
     expect(getCallableNumber('202-555-0113', 'US')).toBe('2025550113');
+    expect(getCallableNumber('8008', 'US')).toBe('8008');
+    expect(getCallableNumber('80.08', 'US')).toBe('8008');
   });
   it('works without a country', () => {
     expect(getCallableNumber('06 75 45')).toBe('067545');
     expect(getCallableNumber('067-545')).toBe('067545');
+    expect(getCallableNumber('8008')).toBe('8008');
+    expect(getCallableNumber('80.08')).toBe('8008');
   });
 });

--- a/src/utils/__tests__/PhoneNumberUtil.test.js
+++ b/src/utils/__tests__/PhoneNumberUtil.test.js
@@ -1,4 +1,4 @@
-import { getDisplayableNumber } from '../PhoneNumberUtil';
+import { getDisplayableNumber, getCallableNumber } from '../PhoneNumberUtil';
 
 describe('Formatting phone numbers', () => {
   it('should not format all phone numbers', () => {
@@ -19,5 +19,18 @@ describe('Formatting phone numbers', () => {
     expect(getDisplayableNumber('067545', 'FR', true)).toBe('06 75 45');
     expect(getDisplayableNumber('+3367545', 'US', true)).toBe('+33 6 75 45');
     expect(getDisplayableNumber('067545', 'US', true)).toBe('067-545');
+  });
+});
+
+describe('getCallableNumber', () => {
+  it('works with a country', () => {
+    expect(getCallableNumber('+33 6 75 45 12 34', 'FR')).toBe('0675451234');
+    expect(getCallableNumber('06 75 45 12 34', 'FR')).toBe('0675451234');
+    expect(getCallableNumber('+1-202-555-0147', 'US')).toBe('2025550147');
+    expect(getCallableNumber('202-555-0113', 'US')).toBe('2025550113');
+  });
+  it('works without a country', () => {
+    expect(getCallableNumber('06 75 45')).toBe('067545');
+    expect(getCallableNumber('067-545')).toBe('067545');
   });
 });


### PR DESCRIPTION
Pair-programming session with @manuquentin. 

@sboily when we use libphonenumber on an unformatted number we got an exception, hence the use of regexp.
Could you give us more insights into what are the expected behaviour?