### PR TITLE
add basic hooks4git config to run test and format before push

### DIFF
--- a/.hooks4git.ini
+++ b/.hooks4git.ini
@@ -1,0 +1,9 @@
+[scripts]
+format = npm run format
+test = npm test
+
+[hooks.pre-commit.scripts]
+
+[hooks.pre-push.scripts]
+run_tests = test
+check_syntax = format

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,3 +1,9 @@
-To publish a new version read this documentation https://docs.npmjs.com/getting-started/publishing-npm-packages
+#### Publishing Package
 
-Build the dist version with `npm run build`
+See `NPM` documentation on [publishing packages](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry):
+
+    npm publish
+
+#### Building Package
+
+    npm run build

--- a/README-dev.md
+++ b/README-dev.md
@@ -7,3 +7,20 @@ See `NPM` documentation on [publishing packages](https://docs.npmjs.com/packages
 #### Building Package
 
     npm run build
+
+### Git Hooks Managent
+
+Due to our Python/JS stack, we recommend [Hooks4git](https://pypi.org/project/hooks4git/) module.
+
+#### Install
+
+**requirements:** [`pip`](https://packaging.python.org/guides/installing-using-linux-tools/#installing-pip-setuptools-wheel-with-linux-package-managers)
+
+    pip install hooks4git --user
+
+#### Usage
+
+    cd working-project/
+    hooks4git --init
+
+Now you get a new `.hooks4git.ini` and some hooks in `.git/hooks`


### PR DESCRIPTION
I want to add the following to https://github.com/tinxhq/wazo-notebook-private/git-hooks.md

---

# [Hooks4git](https://pypi.org/project/hooks4git/)

> Auto checks your code before you ship it. Works with any programmning language.

### Install

**requirements:** [`pip`](https://packaging.python.org/guides/installing-using-linux-tools/#installing-pip-setuptools-wheel-with-linux-package-managers)

    pip install hooks4git --user

### Usage

    cd working-project/
    hooks4git --init

Now you get a new `.hooks4git.ini` and some hooks in `.git/hooks`