### PR TITLE
Fix missing number when parsing favorites

### DIFF
--- a/src/domain/Contact.js
+++ b/src/domain/Contact.js
@@ -227,8 +227,19 @@ export default class Contact {
     return response.results.map(r => Contact.parse(r, response.column_types));
   }
 
+  static parseMultipleNumber(plain: ContactResponse, columns: Array<?string>) {
+    const numberColumns = columns
+      .map((e, index) => ({ index, columnName: e }))
+      .filter(e => e.columnName === 'number')
+      .map(e => e.index);
+    
+    const number = plain.column_values.find((e, index) => numberColumns.some(i => i === index) && e !== null);
+
+    return number || '';
+  }
+
   static parse(plain: ContactResponse, columns: Array<?string>): Contact {
-    const number = plain.column_values[columns.indexOf('number')];
+    const number = Contact.parseMultipleNumber(plain, columns);
     const email = plain.column_values[columns.indexOf('email')];
     return new Contact({
       name: plain.column_values[columns.indexOf('name')],


### PR DESCRIPTION
<img width="227" alt="Capture d’écran 2019-05-07 à 13 56 59" src="https://user-images.githubusercontent.com/14166063/57324061-15f16f80-70d5-11e9-9026-3c719abd066e.png">

Maintenant, on va lire dans les deux colonnes pour determiner le numero plutot que de renvoyer des nulls