### PR TITLE
Fix conference parsing

### DIFF
--- a/src/api/dird.js
+++ b/src/api/dird.js
@@ -90,8 +90,6 @@ export default (client: ApiRequester, baseUrl: string) => ({
 
   fetchWazoContacts(token: Token, source: DirectorySource,
                     queryParams: ContactSearchQueryParams = null): Promise<Contact[]> {
-    console.warn('deprecation warning: consider using "dird.fetchWazoContactsWithParams" instead');
-
     return client
       .get(`${baseUrl}/backends/wazo/sources/${source.uuid}/contacts`, queryParams, token)
       .then(response => Contact.parseManyWazo(response.items, source));

--- a/src/domain/Contact.js
+++ b/src/domain/Contact.js
@@ -421,7 +421,7 @@ export default class Contact {
   static parseConference(single: ConferenceResponse, source: DirectorySource): Contact {
     const numbers = [];
 
-    if (single.extensions[0].exten) {
+    if (single.extensions.length > 0 && single.extensions[0].exten) {
       numbers.push({ label: 'exten', number: single.extensions[0].exten })
     }
 


### PR DESCRIPTION
While parsing conference contacts, verify that you have extensions before accessing first value