### PR TITLE
Convert numerical sourceId to string when parsing conference contacts

### DIFF
--- a/src/domain/Contact.js
+++ b/src/domain/Contact.js
@@ -179,7 +179,7 @@ type WazoResponse = {
 type ConferenceResponse = {
   backend: string,
   name: string,
-  id: string,
+  id: number,
   extensions: Array<{ context: string, exten: string }>,
   incalls: Array<{ context: string, exten: string }>,
 };
@@ -426,7 +426,7 @@ export default class Contact {
     }
 
     return new Contact({
-      sourceId: single.id,
+      sourceId: String(single.id),
       name: single.name,
       numbers,
       source: source.name,


### PR DESCRIPTION
Handle the case where the `sourceId` returned by `https://quintana.wazo.community/0.1/backends/conference/sources/{source_uuid}/contacts` is a number instead of string