### PR TITLE
Fix the way engine versions are compared

### DIFF
--- a/src/domain/Contact.js
+++ b/src/domain/Contact.js
@@ -257,6 +257,7 @@ export default class Contact {
   static parse(plain: ContactResponse, columns: Array<?string>): Contact {
     const number = Contact.parseMultipleNumber(plain, columns);
     const email = plain.column_values[columns.indexOf('email')];
+
     return new Contact({
       name: plain.column_values[columns.indexOf('name')],
       number: number || '',

--- a/src/domain/Session.js
+++ b/src/domain/Session.js
@@ -7,9 +7,10 @@ import Contact from './Contact';
 import Line from './Line';
 import type { UUID, Token } from './types';
 import newFrom from '../utils/new-from';
+import compareVersions from '../utils/compare-version';
 
 const swarmKey = KEYUTIL.getKey(swarmPublicKey);
-const MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT = 19.08;
+const MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT = '19.08';
 
 type Response = {
   data: {
@@ -131,9 +132,7 @@ export default class Session {
 
   primaryContext(): string {
     if (this.engineVersion) {
-      const versionNumber = Number(this.engineVersion);
-
-      if (versionNumber && versionNumber >= MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT) {
+      if (this.hasEngineVersionGte(MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT)) {
         return 'default';
       }
     }
@@ -141,6 +140,10 @@ export default class Session {
     const line = this.primaryLine();
 
     return line && line.extensions.length > 0 ? line.extensions[0].context : 'default';
+  }
+
+  hasEngineVersionGte(version: string) {
+    return this.engineVersion && compareVersions(this.engineVersion, version) >= 0;
   }
 
   primaryNumber(): ?string {

--- a/src/domain/__tests__/Session.test.js
+++ b/src/domain/__tests__/Session.test.js
@@ -267,7 +267,7 @@ describe('Session domain', () => {
     describe('given an engine version', () => {
       describe('that is invalid', () => {
         beforeEach(() => {
-          A_SESSION = new Session({ ...A_SESSION, engineVersion: '19.09-1' });
+          A_SESSION = new Session({ ...A_SESSION, engineVersion: '19.09' });
         });
 
         describe('and NO lines', () => {
@@ -287,7 +287,7 @@ describe('Session domain', () => {
           beforeEach(() => {
             const line = new Line({ extensions: [{ context: SOME_CONTEXT, id: 1, exten: '1' }], id: 1, exten: 1 });
             const profile = new Profile({ lines: [line] });
-            A_SESSION = new Session({ ...A_SESSION, profile });
+            A_SESSION = new Session({ ...A_SESSION, profile, engineVersion: '18.08' });
           });
 
           it('should return line context', async () => {
@@ -337,6 +337,17 @@ describe('Session domain', () => {
 
             expect(context).toEqual(DEFAULT_CONTEXT);
           });
+        });
+      });
+
+      describe('when version is 19.10', () => {
+        it('should not consider that version is 19.1', () => {
+          A_SESSION = new Session({ ...A_SESSION, engineVersion: '19.10' });
+          expect(A_SESSION.hasEngineVersionGte('19.10')).toBeTruthy();
+          expect(A_SESSION.hasEngineVersionGte('19.11')).toBeFalsy();
+          expect(A_SESSION.hasEngineVersionGte('19.09')).toBeTruthy();
+          expect(A_SESSION.hasEngineVersionGte('19.1')).toBeTruthy();
+          expect(A_SESSION.hasEngineVersionGte('19.2')).toBeTruthy();
         });
       });
     });

--- a/src/utils/__tests__/compare-version.test.js
+++ b/src/utils/__tests__/compare-version.test.js
@@ -1,0 +1,11 @@
+import compareVersions from '../compare-version';
+
+describe('Comparing versions', () => {
+  it('should compare non semver versions', () => {
+    expect(compareVersions('1.0', '1.0')).toBe(0);
+    expect(compareVersions('0.10', '0.9')).toBeGreaterThan(0);
+    expect(compareVersions('0.10', '0.11')).toBeLessThan(0);
+    expect(compareVersions('0.10', '0.1')).toBeGreaterThan(0);
+    expect(compareVersions('19.10', '19.1')).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/compare-version.js
+++ b/src/utils/compare-version.js
@@ -1,0 +1,20 @@
+// Can't use `semver` package as Wazo version aren't in semver format
+
+const compareVersions = (a, b) => {
+  let i; let
+    diff;
+  const regExStrip0 = /(\.0+)+$/;
+  const segmentsA = a.replace(regExStrip0, '').split('.');
+  const segmentsB = b.replace(regExStrip0, '').split('.');
+  const l = Math.min(segmentsA.length, segmentsB.length);
+
+  for (i = 0; i < l; i++) {
+    diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10);
+    if (diff) {
+      return diff;
+    }
+  }
+  return segmentsA.length - segmentsB.length;
+};
+
+export default compareVersions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4811,7 +4811,7 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-google-libphonenumber@^3.1.15:
+google-libphonenumber@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.3.tgz#5e5c138c81b8734ebbe5ed354f6cdd22e1b53e95"
   integrity sha512-8n4JyRptifaIRlHANKRlfqLR8fANm7+Q+1qvDuUsUeStSLtLGTVsZWe1llWDfgWTm1y07cEUyiRuNIv6cs2ovg==


### PR DESCRIPTION
⚠️
```js
Number('19.10') === Number('19.1')
```
We should have a real way to compare engine version, instead of comparing version casted in float.