### PR TITLE
[WP-600] Fix lingering notification when stopping tab sharing

### DIFF
--- a/src/domain/Phone/WebRTCPhone.js
+++ b/src/domain/Phone/WebRTCPhone.js
@@ -531,9 +531,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
 
     try {
       if (this.currentScreenShare.stream) {
-        this.currentScreenShare.stream.getTracks()
-          .filter(track => track.kind === 'video')
-          .forEach(track => track.stop());
+        this.currentScreenShare.stream.getTracks().forEach(track => track.stop());
       }
 
       if (restoreLocalStream) {


### PR DESCRIPTION
This should take care of the lingering notification when exiting a tab screensharing session.

![image](https://user-images.githubusercontent.com/11505699/172228528-e96f0f5a-d88b-4d96-96d5-583f0a5cae01.png)
