### PR TITLE
fix(web-rtc-client): require audio unmute before ON_MEDIA_CONNECTED

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wazo/sdk",
-  "version": "0.47.2",
+  "version": "0.47.3-rc.0",
   "description": "Wazo's JavaScript Software Development Kit.",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",

--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -121,12 +121,13 @@ describe('ON_MEDIA_CONNECTED event', () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
     const { session, pc } = makeMockSession();
-    (pc as any).connectionState = 'connecting';
     stubOnAccepted('session-2');
 
     // eslint-disable-next-line no-underscore-dangle
     await (client as any)._onAccepted(session, undefined, false, true);
 
+    // PC reaches 'connected' but audio track is still muted — should NOT emit
+    (pc as any).connectionState = 'connected';
     pc.onconnectionstatechange!();
 
     expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());

--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -35,13 +35,36 @@ describe('ON_MEDIA_CONNECTED event', () => {
     );
   };
 
-  const makeMockSession = () => {
+  const makeMockAudioTrack = (muted = true) => {
+    const listeners: Record<string, Function[]> = {};
+    return {
+      kind: 'audio' as const,
+      muted,
+      addEventListener: jest.fn((event: string, cb: Function) => {
+        listeners[event] = listeners[event] || [];
+        listeners[event].push(cb);
+      }),
+      // Helper to simulate the browser firing 'unmute'
+      _fireUnmute() {
+        this.muted = false;
+        (listeners['unmute'] || []).forEach(cb => cb());
+      },
+    };
+  };
+
+  const makeMockSession = (audioTrackMuted = true) => {
+    const audioTrack = makeMockAudioTrack(audioTrackMuted);
+    const trackListeners: Record<string, Function[]> = {};
     const pc = {
       connectionState: 'new',
       onconnectionstatechange: null as (() => void) | null,
       iceConnectionState: 'new',
       oniceconnectionstatechange: null as (() => void) | null,
-      addEventListener: jest.fn(),
+      addEventListener: jest.fn((event: string, cb: Function) => {
+        trackListeners[event] = trackListeners[event] || [];
+        trackListeners[event].push(cb);
+      }),
+      getReceivers: jest.fn(() => [{ track: audioTrack }]),
     };
     const remoteStream = {
       getTracks: jest.fn(() => []),
@@ -53,27 +76,48 @@ describe('ON_MEDIA_CONNECTED event', () => {
       sessionDescriptionHandler: { peerConnection: pc, remoteMediaStream: remoteStream },
       sessionDescriptionHandlerModifiersReInvite: [],
     } as any;
-    return { session, pc };
+    return { session, pc, audioTrack };
   };
 
-  it('should emit onMediaConnected when pc.connectionState reaches connected', async () => {
+  it('should emit onMediaConnected when both pc connected AND audio track unmuted', async () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
-    const { session, pc } = makeMockSession();
+    const { session, pc, audioTrack } = makeMockSession();
     stubOnAccepted('session-1');
 
     // eslint-disable-next-line no-underscore-dangle
     await (client as any)._onAccepted(session, undefined, false, true);
 
-    expect(pc.onconnectionstatechange).toBeDefined();
-
+    // Connection becomes connected — but audio track is still muted
     (pc as any).connectionState = 'connected';
     pc.onconnectionstatechange!();
+    expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());
 
+    // Audio track unmutes — NOW it should emit
+    audioTrack._fireUnmute();
     expect(emitSpy).toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, session);
   });
 
-  it('should NOT emit onMediaConnected for non-connected states', async () => {
+  it('should emit onMediaConnected when audio unmutes first, then pc connects', async () => {
+    const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
+    spies.push(emitSpy);
+    const { session, pc, audioTrack } = makeMockSession();
+    stubOnAccepted('session-1b');
+
+    // eslint-disable-next-line no-underscore-dangle
+    await (client as any)._onAccepted(session, undefined, false, true);
+
+    // Audio unmutes first — pc not yet connected
+    audioTrack._fireUnmute();
+    expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());
+
+    // Now pc connects
+    (pc as any).connectionState = 'connected';
+    pc.onconnectionstatechange!();
+    expect(emitSpy).toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, session);
+  });
+
+  it('should NOT emit onMediaConnected when only pc connected but audio still muted', async () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
     const { session, pc } = makeMockSession();
@@ -88,11 +132,11 @@ describe('ON_MEDIA_CONNECTED event', () => {
     expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());
   });
 
-  it('should emit onMediaConnected immediately if connectionState is already connected when handler is registered', async () => {
+  it('should emit immediately if both conditions already met when handler is registered', async () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
-    const { session, pc } = makeMockSession();
-    // Simulate connection completing before handler registration
+    // Audio track already unmuted, connection already connected
+    const { session, pc } = makeMockSession(false);
     (pc as any).connectionState = 'connected';
     stubOnAccepted('session-3');
 
@@ -102,18 +146,20 @@ describe('ON_MEDIA_CONNECTED event', () => {
     expect(emitSpy).toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, session);
   });
 
-  it('should not emit onMediaConnected twice if already connected and handler fires', async () => {
+  it('should not emit onMediaConnected twice', async () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
-    const { session, pc } = makeMockSession();
+    const { session, pc, audioTrack } = makeMockSession(false);
     (pc as any).connectionState = 'connected';
     stubOnAccepted('session-4');
 
     // eslint-disable-next-line no-underscore-dangle
     await (client as any)._onAccepted(session, undefined, false, true);
 
-    // Simulate the handler also firing (browser queued event)
+    // Both conditions met at registration — emits once
+    // Simulate handler also firing (browser queued event)
     pc.onconnectionstatechange!();
+    audioTrack._fireUnmute();
 
     const mediaConnectedCalls = emitSpy.mock.calls.filter(
       ([event]) => event === client.ON_MEDIA_CONNECTED,
@@ -124,14 +170,15 @@ describe('ON_MEDIA_CONNECTED event', () => {
   it('should NOT emit onMediaConnected again on re-INVITE for the same session', async () => {
     const emitSpy = jest.spyOn(client.eventEmitter, 'emit');
     spies.push(emitSpy);
-    const { session, pc } = makeMockSession();
+    const { session, pc, audioTrack } = makeMockSession();
     stubOnAccepted('session-5');
 
-    // First _onAccepted: connection reaches 'connected'
+    // First _onAccepted: connection reaches 'connected', audio unmutes
     // eslint-disable-next-line no-underscore-dangle
     await (client as any)._onAccepted(session, undefined, false, true);
     (pc as any).connectionState = 'connected';
     pc.onconnectionstatechange!();
+    audioTrack._fireUnmute();
 
     // Simulate a re-INVITE (e.g. hold/unhold) calling _onAccepted again
     // eslint-disable-next-line no-underscore-dangle

--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -36,31 +36,31 @@ describe('ON_MEDIA_CONNECTED event', () => {
   };
 
   const makeMockAudioTrack = (muted = true) => {
-    const listeners: Record<string, Function[]> = {};
+    const listeners: Record<string, ((...args: any[]) => void)[]> = {};
     return {
       kind: 'audio' as const,
       muted,
-      addEventListener: jest.fn((event: string, cb: Function) => {
+      addEventListener: jest.fn((event: string, cb: (...args: any[]) => void) => {
         listeners[event] = listeners[event] || [];
         listeners[event].push(cb);
       }),
       // Helper to simulate the browser firing 'unmute'
-      _fireUnmute() {
+      fireUnmute() {
         this.muted = false;
-        (listeners['unmute'] || []).forEach(cb => cb());
+        (listeners.unmute || []).forEach(cb => cb());
       },
     };
   };
 
   const makeMockSession = (audioTrackMuted = true) => {
     const audioTrack = makeMockAudioTrack(audioTrackMuted);
-    const trackListeners: Record<string, Function[]> = {};
+    const trackListeners: Record<string, ((...args: any[]) => void)[]> = {};
     const pc = {
       connectionState: 'new',
       onconnectionstatechange: null as (() => void) | null,
       iceConnectionState: 'new',
       oniceconnectionstatechange: null as (() => void) | null,
-      addEventListener: jest.fn((event: string, cb: Function) => {
+      addEventListener: jest.fn((event: string, cb: (...args: any[]) => void) => {
         trackListeners[event] = trackListeners[event] || [];
         trackListeners[event].push(cb);
       }),
@@ -94,7 +94,7 @@ describe('ON_MEDIA_CONNECTED event', () => {
     expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());
 
     // Audio track unmutes — NOW it should emit
-    audioTrack._fireUnmute();
+    audioTrack.fireUnmute();
     expect(emitSpy).toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, session);
   });
 
@@ -108,7 +108,7 @@ describe('ON_MEDIA_CONNECTED event', () => {
     await (client as any)._onAccepted(session, undefined, false, true);
 
     // Audio unmutes first — pc not yet connected
-    audioTrack._fireUnmute();
+    audioTrack.fireUnmute();
     expect(emitSpy).not.toHaveBeenCalledWith(client.ON_MEDIA_CONNECTED, expect.anything());
 
     // Now pc connects
@@ -159,7 +159,7 @@ describe('ON_MEDIA_CONNECTED event', () => {
     // Both conditions met at registration — emits once
     // Simulate handler also firing (browser queued event)
     pc.onconnectionstatechange!();
-    audioTrack._fireUnmute();
+    audioTrack.fireUnmute();
 
     const mediaConnectedCalls = emitSpy.mock.calls.filter(
       ([event]) => event === client.ON_MEDIA_CONNECTED,
@@ -178,7 +178,7 @@ describe('ON_MEDIA_CONNECTED event', () => {
     await (client as any)._onAccepted(session, undefined, false, true);
     (pc as any).connectionState = 'connected';
     pc.onconnectionstatechange!();
-    audioTrack._fireUnmute();
+    audioTrack.fireUnmute();
 
     // Simulate a re-INVITE (e.g. hold/unhold) calling _onAccepted again
     // eslint-disable-next-line no-underscore-dangle

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2337,23 +2337,55 @@ export default class WebRTCClient extends Emitter {
     if (pc) {
       const currentSessionId = this.getSipSessionId(session);
 
+      const emitMediaConnectedOnce = () => {
+        if (this.mediaConnectedSessions[currentSessionId]) {
+          return;
+        }
+
+        // Require both: connection established AND remote audio track unmuted
+        // (i.e. first audio frame decoded). This prevents sending HID offHook
+        // before audio is actually flowing, which causes some headsets to enter
+        // a Line Busy Tone state.
+        if (pc.connectionState !== 'connected') {
+          return;
+        }
+
+        const receivers = pc.getReceivers();
+        const audioReceiver = receivers.find(r => r.track?.kind === 'audio');
+        if (audioReceiver?.track?.muted !== false) {
+          return;
+        }
+
+        this.mediaConnectedSessions[currentSessionId] = true;
+        this.eventEmitter.emit(ON_MEDIA_CONNECTED, session);
+      };
+
       pc.onconnectionstatechange = () => {
         logger.info('on peer connection state changed', {
           state: pc.connectionState,
           sessionId: currentSessionId,
         });
 
-        if (pc.connectionState === 'connected' && !this.mediaConnectedSessions[currentSessionId]) {
-          this.mediaConnectedSessions[currentSessionId] = true;
-          this.eventEmitter.emit(ON_MEDIA_CONNECTED, session);
-        }
+        emitMediaConnectedOnce();
       };
 
-      // Handle case where connection reached 'connected' before handler was registered
-      if (pc.connectionState === 'connected' && !this.mediaConnectedSessions[currentSessionId]) {
-        this.mediaConnectedSessions[currentSessionId] = true;
-        this.eventEmitter.emit(ON_MEDIA_CONNECTED, session);
-      }
+      // Listen for remote audio track unmute
+      const receivers = pc.getReceivers();
+      receivers.forEach(receiver => {
+        if (receiver.track?.kind === 'audio') {
+          receiver.track.addEventListener('unmute', emitMediaConnectedOnce);
+        }
+      });
+
+      // Also listen on future tracks (re-INVITE, etc.)
+      pc.addEventListener('track', (event: RTCTrackEvent) => {
+        if (event.track.kind === 'audio') {
+          event.track.addEventListener('unmute', emitMediaConnectedOnce);
+        }
+      });
+
+      // Handle case where both conditions are already met
+      emitMediaConnectedOnce();
 
       pc.oniceconnectionstatechange = () => {
         logger.info('on ice connection state changed', {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2350,7 +2350,7 @@ export default class WebRTCClient extends Emitter {
           return;
         }
 
-        const receivers = pc.getReceivers();
+        const receivers = pc.getReceivers ? pc.getReceivers() : [];
         const audioReceiver = receivers.find(r => r.track?.kind === 'audio');
         if (audioReceiver?.track?.muted !== false) {
           return;
@@ -2370,7 +2370,7 @@ export default class WebRTCClient extends Emitter {
       };
 
       // Listen for remote audio track unmute
-      const receivers = pc.getReceivers();
+      const receivers = pc.getReceivers ? pc.getReceivers() : [];
       receivers.forEach(receiver => {
         if (receiver.track?.kind === 'audio') {
           receiver.track.addEventListener('unmute', emitMediaConnectedOnce);

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2381,6 +2381,8 @@ export default class WebRTCClient extends Emitter {
       pc.addEventListener('track', (event: RTCTrackEvent) => {
         if (event.track.kind === 'audio') {
           event.track.addEventListener('unmute', emitMediaConnectedOnce);
+          // Handle case where track arrives already unmuted
+          emitMediaConnectedOnce();
         }
       });
 


### PR DESCRIPTION
## Summary
- Delay `ON_MEDIA_CONNECTED` emission until both `pc.connectionState === 'connected'` **and** the remote audio track is unmuted (first audio frame decoded)
- Prevents HID offHook from being sent before audio is actually flowing, which causes some headsets to enter a Line Busy Tone state
- Adds `emitMediaConnectedOnce()` closure that checks both conditions idempotently, triggered from `onconnectionstatechange`, audio track `unmute` event, and an immediate check at registration time

## Test plan
- [x] Test: emits when pc connects first, then audio unmutes
- [x] Test: emits when audio unmutes first, then pc connects
- [x] Test: does NOT emit when only pc connected but audio still muted
- [x] Test: emits immediately if both conditions already met at registration
- [x] Test: no double emission
- [x] Test: no re-emission on re-INVITE for same session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the semantics/timing of `ON_MEDIA_CONNECTED` emission in call setup, which could affect downstream call-state handling and headset integrations despite being localized and well-tested.
> 
> **Overview**
> Delays `ON_MEDIA_CONNECTED` in `WebRTCClient._onAccepted` until *both* the peer connection is `connected` **and** the remote audio track has fired `unmute` (first audio decoded), emitting idempotently via a shared `emitMediaConnectedOnce` check wired to `connectionstatechange`, existing/future audio tracks, and an immediate registration-time check.
> 
> Updates unit tests to cover both event orderings (connect-first vs unmute-first), ensure no emission when audio remains muted, and verify no double-emits or re-emits on re-INVITE; also bumps the package version to `0.47.3-rc.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a91eb1f6998b14b09228c36372ee7d1527edbb19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->