### PR TITLE
[BUG-179] fix: preserve audio constraints during device switch and improve stream reacquisition

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -301,6 +301,84 @@ describe('changeAudioInputDevice', () => {
       enumerateDevices: enumerateDevicesMock,
     },
   });
+  it('should preserve audio processing constraints when switching device', async () => {
+    const audioConstraints = {
+      audio: {
+        deviceId: { exact: 'old-device' },
+        echoCancellation: true,
+        noiseSuppression: false,
+        autoGainControl: true,
+      },
+      video: null,
+    };
+    client.setMediaConstraints(audioConstraints as any);
+
+    await client.changeAudioInputDevice('new-device', session as any);
+
+    expect((client as any).audio).toEqual({
+      deviceId: { exact: 'new-device' },
+      echoCancellation: true,
+      noiseSuppression: false,
+      autoGainControl: true,
+    });
+  });
+
+  it('should pass preserved audio processing constraints to getUserMedia', async () => {
+    getUserMediaMock.mockClear();
+    const audioConstraints = {
+      audio: {
+        deviceId: { exact: 'old-device' },
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+      video: null,
+    };
+    client.setMediaConstraints(audioConstraints as any);
+
+    await client.changeAudioInputDevice('new-device', session as any);
+
+    expect(getUserMediaMock).toHaveBeenCalledWith({
+      audio: {
+        deviceId: { exact: 'new-device' },
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: false,
+      },
+    });
+  });
+
+  it('should not preserve non-processing audio constraints (only echoCancellation, noiseSuppression, autoGainControl)', async () => {
+    const audioConstraints = {
+      audio: {
+        deviceId: { exact: 'old-device' },
+        echoCancellation: true,
+        sampleRate: 48000,
+        channelCount: 2,
+      },
+      video: null,
+    };
+    client.setMediaConstraints(audioConstraints as any);
+
+    await client.changeAudioInputDevice('new-device', session as any);
+
+    // sampleRate and channelCount should NOT be preserved
+    expect((client as any).audio).toEqual({
+      deviceId: { exact: 'new-device' },
+      echoCancellation: true,
+    });
+  });
+
+  it('should handle audio=true (boolean) without errors during device switch', async () => {
+    client.setMediaConstraints({ audio: true, video: null } as any);
+
+    await client.changeAudioInputDevice('new-device', session as any);
+
+    expect((client as any).audio).toEqual({
+      deviceId: { exact: 'new-device' },
+    });
+  });
+
   it('should change the audio input track if the provided id is different', async () => {
     client.setMediaConstraints(constraints as any);
     expect(client.getAudioDeviceId()).toBe(defaultId);

--- a/src/lib/WazoSessionDescriptionHandler.ts
+++ b/src/lib/WazoSessionDescriptionHandler.ts
@@ -557,8 +557,8 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
       if (a.length !== b.length) return false;
       return a.every((val: any, i: number) => this._constraintsEqual(val, b[i]));
     }
-    const keysA = Object.keys(a).sort();
-    const keysB = Object.keys(b).sort();
+    const keysA = Object.keys(a).sort((x, y) => x.localeCompare(y));
+    const keysB = Object.keys(b).sort((x, y) => x.localeCompare(y));
     if (keysA.length !== keysB.length) return false;
     return keysA.every((key, i) => keysB[i] === key && this._constraintsEqual(a[key], b[key]));
   }

--- a/src/lib/WazoSessionDescriptionHandler.ts
+++ b/src/lib/WazoSessionDescriptionHandler.ts
@@ -524,13 +524,13 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
       // if constraints have not changed, do not get a new media stream
       // @ts-ignore: private
       if (this._constraintsEqual(this.localMediaStreamConstraints.audio, constraints.audio) && this._constraintsEqual(this.localMediaStreamConstraints.video, constraints.video)) {
-        // Also verify existing stream has an active audio track before skipping
-        const existingAudioTracks = this._localMediaStream?.getAudioTracks() || [];
-        const hasActiveAudioTrack = existingAudioTracks.some((t: MediaStreamTrack) => t.readyState === 'live' && t.enabled);
-        if (hasActiveAudioTrack) {
+        // Verify existing stream has active tracks for the requested media types before skipping
+        const hasActiveAudio = !constraints.audio || (this._localMediaStream?.getAudioTracks() || []).some((t: MediaStreamTrack) => t.readyState === 'live' && t.enabled);
+        const hasActiveVideo = !constraints.video || (this._localMediaStream?.getVideoTracks() || []).some((t: MediaStreamTrack) => t.readyState === 'live' && t.enabled);
+        if (hasActiveAudio && hasActiveVideo) {
           return Promise.resolve();
         }
-        // No active audio track -- fall through to get a new stream
+        // Missing active track for a requested media type -- fall through to get a new stream
       }
     } else if (constraints.audio === undefined && constraints.video === undefined) {
       // if no constraints have been specified, default to audio for initial media stream
@@ -552,6 +552,11 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
     if (a === b) return true;
     if (typeof a !== typeof b) return false;
     if (typeof a !== 'object' || a === null || b === null) return a === b;
+    if (Array.isArray(a) !== Array.isArray(b)) return false;
+    if (Array.isArray(a)) {
+      if (a.length !== b.length) return false;
+      return a.every((val: any, i: number) => this._constraintsEqual(val, b[i]));
+    }
     const keysA = Object.keys(a).sort();
     const keysB = Object.keys(b).sort();
     if (keysA.length !== keysB.length) return false;

--- a/src/lib/WazoSessionDescriptionHandler.ts
+++ b/src/lib/WazoSessionDescriptionHandler.ts
@@ -523,8 +523,14 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
     if (this.localMediaStreamConstraints) {
       // if constraints have not changed, do not get a new media stream
       // @ts-ignore: private
-      if (JSON.stringify(this.localMediaStreamConstraints.audio) === JSON.stringify(constraints.audio) && JSON.stringify(this.localMediaStreamConstraints.video) === JSON.stringify(constraints.video)) {
-        return Promise.resolve();
+      if (this._constraintsEqual(this.localMediaStreamConstraints.audio, constraints.audio) && this._constraintsEqual(this.localMediaStreamConstraints.video, constraints.video)) {
+        // Also verify existing stream has an active audio track before skipping
+        const existingAudioTracks = this._localMediaStream?.getAudioTracks() || [];
+        const hasActiveAudioTrack = existingAudioTracks.some((t: MediaStreamTrack) => t.readyState === 'live' && t.enabled);
+        if (hasActiveAudioTrack) {
+          return Promise.resolve();
+        }
+        // No active audio track -- fall through to get a new stream
       }
     } else if (constraints.audio === undefined && constraints.video === undefined) {
       // if no constraints have been specified, default to audio for initial media stream
@@ -539,6 +545,17 @@ class WazoSessionDescriptionHandler extends SessionDescriptionHandler {
       this.setLocalMediaStream(mediaStream);
       return mediaStream;
     });
+  }
+
+  // Order-independent deep comparison for media constraints
+  private _constraintsEqual(a: any, b: any): boolean {
+    if (a === b) return true;
+    if (typeof a !== typeof b) return false;
+    if (typeof a !== 'object' || a === null || b === null) return a === b;
+    const keysA = Object.keys(a).sort();
+    const keysB = Object.keys(b).sort();
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every((key, i) => keysB[i] === key && this._constraintsEqual(a[key], b[key]));
   }
 
 }

--- a/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
+++ b/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
@@ -48,6 +48,7 @@ describe('WazoSessionDescriptionHandler._constraintsEqual', () => {
   const handler = createHandler();
 
   // Access private method for testing
+  // eslint-disable-next-line no-underscore-dangle
   const constraintsEqual = (a: any, b: any) => (handler as any)._constraintsEqual(a, b);
 
   describe('primitive values', () => {

--- a/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
+++ b/src/lib/__tests__/WazoSessionDescriptionHandler.test.ts
@@ -44,6 +44,310 @@ const createHandler = (pc?: any) => {
   return handler;
 };
 
+describe('WazoSessionDescriptionHandler._constraintsEqual', () => {
+  const handler = createHandler();
+
+  // Access private method for testing
+  const constraintsEqual = (a: any, b: any) => (handler as any)._constraintsEqual(a, b);
+
+  describe('primitive values', () => {
+    it('returns true for identical primitives', () => {
+      expect(constraintsEqual(true, true)).toBe(true);
+      expect(constraintsEqual(false, false)).toBe(true);
+      expect(constraintsEqual(42, 42)).toBe(true);
+      expect(constraintsEqual('ideal', 'ideal')).toBe(true);
+    });
+
+    it('returns true for reference-equal values', () => {
+      const obj = { deviceId: 'abc' };
+      expect(constraintsEqual(obj, obj)).toBe(true);
+    });
+
+    it('returns false for different primitives', () => {
+      expect(constraintsEqual(true, false)).toBe(false);
+      expect(constraintsEqual(42, 99)).toBe(false);
+      expect(constraintsEqual('a', 'b')).toBe(false);
+    });
+
+    it('returns false for type mismatches', () => {
+      expect(constraintsEqual(true, { exact: true })).toBe(false);
+      expect(constraintsEqual(42, '42')).toBe(false);
+      expect(constraintsEqual(null, undefined)).toBe(false);
+    });
+  });
+
+  describe('null handling', () => {
+    it('returns true for null === null', () => {
+      expect(constraintsEqual(null, null)).toBe(true);
+    });
+
+    it('returns false for null vs object', () => {
+      expect(constraintsEqual(null, {})).toBe(false);
+      expect(constraintsEqual({}, null)).toBe(false);
+    });
+  });
+
+  describe('order-independent object comparison', () => {
+    it('returns true when keys are in the same order', () => {
+      expect(constraintsEqual(
+        { deviceId: { exact: 'mic1' }, echoCancellation: true },
+        { deviceId: { exact: 'mic1' }, echoCancellation: true },
+      )).toBe(true);
+    });
+
+    it('returns true when keys are in different order', () => {
+      expect(constraintsEqual(
+        { echoCancellation: true, deviceId: { exact: 'mic1' } },
+        { deviceId: { exact: 'mic1' }, echoCancellation: true },
+      )).toBe(true);
+    });
+
+    it('returns false when key counts differ', () => {
+      expect(constraintsEqual(
+        { deviceId: 'mic1' },
+        { deviceId: 'mic1', echoCancellation: true },
+      )).toBe(false);
+    });
+
+    it('returns false when values differ for same keys', () => {
+      expect(constraintsEqual(
+        { echoCancellation: true, noiseSuppression: false },
+        { echoCancellation: true, noiseSuppression: true },
+      )).toBe(false);
+    });
+  });
+
+  describe('nested objects', () => {
+    it('compares deeply nested structures with different key order', () => {
+      const a = {
+        deviceId: { exact: 'mic1' },
+        echoCancellation: true,
+        autoGainControl: false,
+      };
+      const b = {
+        autoGainControl: false,
+        deviceId: { exact: 'mic1' },
+        echoCancellation: true,
+      };
+      expect(constraintsEqual(a, b)).toBe(true);
+    });
+
+    it('detects differences in deeply nested values', () => {
+      expect(constraintsEqual(
+        { deviceId: { exact: 'mic1' } },
+        { deviceId: { exact: 'mic2' } },
+      )).toBe(false);
+    });
+  });
+
+  describe('array comparison', () => {
+    it('returns true for identical arrays', () => {
+      expect(constraintsEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    });
+
+    it('returns false for different length arrays', () => {
+      expect(constraintsEqual([1, 2], [1, 2, 3])).toBe(false);
+    });
+
+    it('returns false for same elements in different order', () => {
+      expect(constraintsEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+    });
+
+    it('returns false for array vs non-array', () => {
+      expect(constraintsEqual([1], { 0: 1 })).toBe(false);
+      expect(constraintsEqual({ 0: 1 }, [1])).toBe(false);
+    });
+  });
+
+  describe('real-world media constraint scenarios', () => {
+    it('matches typical audio constraints regardless of key order', () => {
+      const fromSdk = {
+        deviceId: { exact: 'abc-123' },
+        autoGainControl: true,
+        noiseSuppression: true,
+        echoCancellation: true,
+      };
+      const fromBrowser = {
+        echoCancellation: true,
+        autoGainControl: true,
+        deviceId: { exact: 'abc-123' },
+        noiseSuppression: true,
+      };
+      expect(constraintsEqual(fromSdk, fromBrowser)).toBe(true);
+    });
+
+    it('detects device change in constraints with same processing flags', () => {
+      const before = {
+        deviceId: { exact: 'mic-old' },
+        echoCancellation: true,
+        noiseSuppression: true,
+      };
+      const after = {
+        deviceId: { exact: 'mic-new' },
+        echoCancellation: true,
+        noiseSuppression: true,
+      };
+      expect(constraintsEqual(before, after)).toBe(false);
+    });
+
+    it('handles boolean true vs constraint object (actual device switch scenario)', () => {
+      // Before device switch: audio = true
+      // After device switch: audio = { deviceId: { exact: 'mic1' } }
+      expect(constraintsEqual(true, { deviceId: { exact: 'mic1' } })).toBe(false);
+    });
+
+    it('handles undefined vs undefined', () => {
+      expect(constraintsEqual(undefined, undefined)).toBe(true);
+    });
+  });
+});
+
+describe('WazoSessionDescriptionHandler.getLocalMediaStream', () => {
+  const mediaStreamFactory = jest.fn();
+
+  const createHandlerWithStream = (opts: {
+    storedConstraints?: any;
+    audioTracks?: Array<{ readyState: string; enabled: boolean }>;
+    videoTracks?: Array<{ readyState: string; enabled: boolean }>;
+  } = {}) => {
+    const logger = { debug: jest.fn(), error: jest.fn() };
+    const h = new WazoSessionDescriptionHandler(
+      logger as any,
+      mediaStreamFactory as any,
+      {} as any,
+      true,
+      {} as any,
+    );
+    // eslint-disable-next-line no-underscore-dangle
+    (h as any)._peerConnection = {}; // must be defined
+    (h as any).mediaStreamFactory = mediaStreamFactory;
+    if (opts.storedConstraints) {
+      (h as any).localMediaStreamConstraints = opts.storedConstraints;
+    }
+    // eslint-disable-next-line no-underscore-dangle
+    (h as any)._localMediaStream = {
+      getAudioTracks: () => opts.audioTracks || [],
+      getVideoTracks: () => opts.videoTracks || [],
+    };
+    h.setLocalMediaStream = jest.fn();
+    return h;
+  };
+
+  const fakeStream = { getTracks: () => [] };
+
+  beforeEach(() => {
+    mediaStreamFactory.mockReset();
+    mediaStreamFactory.mockResolvedValue(fakeStream);
+  });
+
+  it('skips getUserMedia when constraints match and tracks are active', async () => {
+    const constraints = {
+      audio: { deviceId: { exact: 'mic1' }, echoCancellation: true },
+      video: false,
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: constraints,
+      audioTracks: [{ readyState: 'live', enabled: true }],
+    });
+
+    await h.getLocalMediaStream({ constraints });
+
+    expect(mediaStreamFactory).not.toHaveBeenCalled();
+  });
+
+  it('fetches new stream when constraints match but audio track has ended', async () => {
+    const constraints = {
+      audio: { deviceId: { exact: 'mic1' } },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: constraints,
+      audioTracks: [{ readyState: 'ended', enabled: true }],
+    });
+
+    await h.getLocalMediaStream({ constraints });
+
+    expect(mediaStreamFactory).toHaveBeenCalledWith(constraints, h);
+  });
+
+  it('fetches new stream when constraints match but audio track is disabled', async () => {
+    const constraints = {
+      audio: { deviceId: { exact: 'mic1' } },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: constraints,
+      audioTracks: [{ readyState: 'live', enabled: false }],
+    });
+
+    await h.getLocalMediaStream({ constraints });
+
+    expect(mediaStreamFactory).toHaveBeenCalledWith(constraints, h);
+  });
+
+  it('fetches new stream when constraints match but no audio tracks exist', async () => {
+    const constraints = {
+      audio: { deviceId: { exact: 'mic1' } },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: constraints,
+      audioTracks: [],
+    });
+
+    await h.getLocalMediaStream({ constraints });
+
+    expect(mediaStreamFactory).toHaveBeenCalledWith(constraints, h);
+  });
+
+  it('skips when audio not requested even with no audio tracks', async () => {
+    const constraints = {
+      audio: false,
+      video: { deviceId: { exact: 'cam1' } },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: constraints,
+      audioTracks: [],
+      videoTracks: [{ readyState: 'live', enabled: true }],
+    });
+
+    await h.getLocalMediaStream({ constraints });
+
+    expect(mediaStreamFactory).not.toHaveBeenCalled();
+  });
+
+  it('fetches new stream when constraints differ (order-independent)', async () => {
+    const stored = {
+      audio: { deviceId: { exact: 'mic1' } },
+    };
+    const incoming = {
+      audio: { deviceId: { exact: 'mic2' } },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: stored,
+      audioTracks: [{ readyState: 'live', enabled: true }],
+    });
+
+    await h.getLocalMediaStream({ constraints: incoming });
+
+    expect(mediaStreamFactory).toHaveBeenCalledWith(incoming, h);
+  });
+
+  it('skips when constraints match with keys in different order and tracks are active', async () => {
+    const stored = {
+      audio: { echoCancellation: true, deviceId: { exact: 'mic1' } },
+    };
+    const incoming = {
+      audio: { deviceId: { exact: 'mic1' }, echoCancellation: true },
+    };
+    const h = createHandlerWithStream({
+      storedConstraints: stored,
+      audioTracks: [{ readyState: 'live', enabled: true }],
+    });
+
+    await h.getLocalMediaStream({ constraints: incoming });
+
+    expect(mediaStreamFactory).not.toHaveBeenCalled();
+  });
+});
+
 describe('WazoSessionDescriptionHandler.updateDirection', () => {
   describe('guard checks', () => {
     it('rejects when _peerConnection is undefined', async () => {

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1320,12 +1320,16 @@ export default class WebRTCClient extends Emitter {
       }
     }
 
-    // let's update the local audio value
+    // let's update the local audio value, preserving audio processing constraints
     if (this.audio) {
+      const prevAudio = typeof this.audio === 'object' ? this.audio : {};
       this.audio = {
         deviceId: {
           exact: deviceId,
         },
+        ...('autoGainControl' in prevAudio ? { autoGainControl: prevAudio.autoGainControl } : {}),
+        ...('noiseSuppression' in prevAudio ? { noiseSuppression: prevAudio.noiseSuppression } : {}),
+        ...('echoCancellation' in prevAudio ? { echoCancellation: prevAudio.echoCancellation } : {}),
       };
     }
 
@@ -1333,7 +1337,7 @@ export default class WebRTCClient extends Emitter {
       const sdh = session.sessionDescriptionHandler as SessionDescriptionHandler;
       const pc = sdh?.peerConnection;
       const constraints = {
-        audio: {
+        audio: typeof this.audio === 'object' ? { ...this.audio, deviceId: { exact: deviceId } } : {
           deviceId: {
             exact: deviceId,
           },

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1343,6 +1343,7 @@ export default class WebRTCClient extends Emitter {
           },
         },
       };
+      logger.info('changing audio input device with constraints', { constraints });
       const stream = await navigator.mediaDevices.getUserMedia(constraints);
       const audioTrack = stream.getAudioTracks()[0];
       const sender = pc && pc.getSenders && pc.getSenders().find((s) => audioTrack && s && s.track && s.track.kind === audioTrack.kind);


### PR DESCRIPTION
- **Preserve audio processing constraints during mid-call device switch** — `changeAudioInputDevice` was overwriting `this.audio` with only `deviceId`, stripping `autoGainControl`/`noiseSuppression`/`echoCancellation`. The browser then applied its defaults (e.g. `autoGainControl: true`), conflicting with USB headset DSP and causing weak audio during the first seconds of calls.
- **Replace `JSON.stringify` constraint comparison with order-independent deep equality** — prevents false mismatches when constraint object keys are reordered, which would unnecessarily re-acquire the media stream.
- **Verify active tracks before skipping stream reacquisition** — even when constraints match, check that the existing stream actually has live, enabled tracks for all requested media types before short-circuiting.

## Changes
- `src/web-rtc-client.ts` — Preserve `autoGainControl`, `noiseSuppression`, and `echoCancellation` when updating the audio device ID; pass full constraints to `getUserMedia` during mid-call switch.
- `src/lib/WazoSessionDescriptionHandler.ts` — Add `_constraintsEqual()` for order-independent deep comparison; validate active audio/video tracks before skipping `getLocalMediaStream`.

