### PR TITLE
ITEM-302 Add SIP header diversion in call session

### DIFF
--- a/src/domain/CallSession.ts
+++ b/src/domain/CallSession.ts
@@ -333,7 +333,11 @@ export default class CallSession {
   }
 
   updateFrom(session: CallSession) {
+    const preservedDiversion = this.diversion;
     updateFrom(this, session);
+    if (!session.diversion?.length && preservedDiversion?.length) {
+      this.diversion = preservedDiversion;
+    }
   }
 
   separateDisplayName(): {

--- a/src/domain/CallSession.ts
+++ b/src/domain/CallSession.ts
@@ -14,6 +14,7 @@ type CallSessionArguments = {
   cameraEnabled: boolean;
   creationTime?: Date | null | undefined;
   dialedExtension?: string | null;
+  diversion?: string[];
   displayName: string;
   endTime?: Date | null | undefined;
   isCaller: boolean;
@@ -67,6 +68,8 @@ export default class CallSession {
 
   dialedExtension: string;
 
+  diversion: string[];
+
   ringing: boolean;
 
   // Should be computed ?
@@ -119,6 +122,7 @@ export default class CallSession {
     endTime,
     cameraEnabled,
     dialedExtension,
+    diversion,
     sipCallId,
     sipStatus,
     callerNumber,
@@ -151,6 +155,7 @@ export default class CallSession {
     this.callerNumber = callerNumber;
     this.cameraEnabled = cameraEnabled;
     this.dialedExtension = dialedExtension || '';
+    this.diversion = diversion ?? [];
     this.call = call;
     this.sipStatus = sipStatus;
     this.autoAnswer = autoAnswer || false;

--- a/src/domain/CallSession.ts
+++ b/src/domain/CallSession.ts
@@ -68,7 +68,7 @@ export default class CallSession {
 
   dialedExtension: string;
 
-  diversion: string[];
+  diversion?: string[];
 
   ringing: boolean;
 
@@ -155,7 +155,7 @@ export default class CallSession {
     this.callerNumber = callerNumber;
     this.cameraEnabled = cameraEnabled;
     this.dialedExtension = dialedExtension || '';
-    this.diversion = diversion ?? [];
+    this.diversion = diversion;
     this.call = call;
     this.sipStatus = sipStatus;
     this.autoAnswer = autoAnswer || false;
@@ -333,11 +333,7 @@ export default class CallSession {
   }
 
   updateFrom(session: CallSession) {
-    const preservedDiversion = this.diversion;
     updateFrom(this, session);
-    if (!session.diversion?.length && preservedDiversion?.length) {
-      this.diversion = preservedDiversion;
-    }
   }
 
   separateDisplayName(): {

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1851,7 +1851,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       recordingPaused: fromSession ? fromSession.isRecordingPaused() : false,
       recordingState: fromSession ? fromSession.recordingState : RECORDING_STATE.INACTIVE,
       sipSession,
-      diversion: sipSession?.diversion ?? fromSession?.diversion ?? [],
+      diversion: sipSession?.diversion ?? [],
       conference: !!fromSession && fromSession.isConference(),
       ...extra,
     });

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1851,7 +1851,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       recordingPaused: fromSession ? fromSession.isRecordingPaused() : false,
       recordingState: fromSession ? fromSession.recordingState : RECORDING_STATE.INACTIVE,
       sipSession,
-      diversion: sipSession?.diversion ?? [],
+      diversion: sipSession?.diversion,
       conference: !!fromSession && fromSession.isConference(),
       ...extra,
     });

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -1851,6 +1851,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       recordingPaused: fromSession ? fromSession.isRecordingPaused() : false,
       recordingState: fromSession ? fromSession.recordingState : RECORDING_STATE.INACTIVE,
       sipSession,
+      diversion: sipSession?.diversion ?? fromSession?.diversion ?? [],
       conference: !!fromSession && fromSession.isConference(),
       ...extra,
     });

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -103,17 +103,7 @@ describe('WebRTCPhone._createCallSession diversion', () => {
     expect(cs.diversion).toEqual(SAMPLE);
   });
 
-  it('falls back to fromSession.diversion when sipSession lacks one', () => {
-    const sipSession = { id: 'session-1' } as any;
-    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
-    const previous = new CallSession({ callId: 'a', sipCallId: 'session-1', diversion: SAMPLE } as any);
-
-    const cs = phone._createCallSession(sipSession, previous);
-
-    expect(cs.diversion).toEqual(SAMPLE);
-  });
-
-  it('defaults to an empty array when neither sipSession nor fromSession has diversion', () => {
+  it('defaults to an empty array when the sipSession has no diversion', () => {
     const sipSession = { id: 'session-1' } as any;
     const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
 

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -92,7 +92,7 @@ describe('WebRTCPhone._createCallSession diversion', () => {
     isCallHeld: () => false,
     hasVideo: () => false,
     isAudioMuted: () => false,
-  } as any);
+  });
 
   it('propagates diversion from the sipSession', () => {
     const sipSession = { id: 'session-1', diversion: SAMPLE } as any;

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -82,3 +82,44 @@ describe('WebRTCPhone.findSipSession', () => {
     expect(result).toBeNull();
   });
 });
+
+/* eslint-disable no-underscore-dangle */
+describe('WebRTCPhone._createCallSession diversion', () => {
+  const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
+
+  const createCreatableMockClient = (sessions: Record<string, any> = {}) => ({
+    ...createMockClient(sessions),
+    isCallHeld: () => false,
+    hasVideo: () => false,
+    isAudioMuted: () => false,
+  } as any);
+
+  it('propagates diversion from the sipSession', () => {
+    const sipSession = { id: 'session-1', diversion: SAMPLE } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.diversion).toEqual(SAMPLE);
+  });
+
+  it('falls back to fromSession.diversion when sipSession lacks one', () => {
+    const sipSession = { id: 'session-1' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+    const previous = new CallSession({ callId: 'a', sipCallId: 'session-1', diversion: SAMPLE } as any);
+
+    const cs = phone._createCallSession(sipSession, previous);
+
+    expect(cs.diversion).toEqual(SAMPLE);
+  });
+
+  it('defaults to an empty array when neither sipSession nor fromSession has diversion', () => {
+    const sipSession = { id: 'session-1' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.diversion).toEqual([]);
+  });
+});
+/* eslint-enable no-underscore-dangle */

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -103,13 +103,13 @@ describe('WebRTCPhone._createCallSession diversion', () => {
     expect(cs.diversion).toEqual(SAMPLE);
   });
 
-  it('defaults to an empty array when the sipSession has no diversion', () => {
+  it('is undefined when the sipSession has no diversion', () => {
     const sipSession = { id: 'session-1' } as any;
     const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
 
     const cs = phone._createCallSession(sipSession);
 
-    expect(cs.diversion).toEqual([]);
+    expect(cs.diversion).toBeUndefined();
   });
 });
 /* eslint-enable no-underscore-dangle */

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -117,9 +117,9 @@ describe('CallSession domain', () => {
   describe('diversion field', () => {
     const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
 
-    it('defaults to an empty array when not provided', () => {
+    it('is undefined when not provided', () => {
       const cs = new CallSession({} as any);
-      expect(cs.diversion).toEqual([]);
+      expect(cs.diversion).toBeUndefined();
     });
 
     it('copies diversion via updateFrom', () => {
@@ -134,6 +134,13 @@ describe('CallSession domain', () => {
       const next = new CallSession({ callId: 'a' } as any);
       cs.updateFrom(next);
       expect(cs.diversion).toEqual(SAMPLE);
+    });
+
+    it('clears diversion when source explicitly sets an empty array', () => {
+      const cs = new CallSession({ callId: 'a', diversion: SAMPLE } as any);
+      const next = new CallSession({ callId: 'a', diversion: [] } as any);
+      cs.updateFrom(next);
+      expect(cs.diversion).toEqual([]);
     });
 
     it('preserves diversion through JSON serialization', () => {

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -122,11 +122,18 @@ describe('CallSession domain', () => {
       expect(cs.diversion).toEqual([]);
     });
 
-    it('preserves diversion through updateFrom', () => {
+    it('copies diversion via updateFrom', () => {
       const cs = new CallSession({ callId: 'a', diversion: SAMPLE } as any);
       const next = new CallSession({ callId: 'a' } as any);
       next.updateFrom(cs);
       expect(next.diversion).toEqual(SAMPLE);
+    });
+
+    it('does not clobber diversion when source lacks one', () => {
+      const cs = new CallSession({ callId: 'a', diversion: SAMPLE } as any);
+      const next = new CallSession({ callId: 'a' } as any);
+      cs.updateFrom(next);
+      expect(cs.diversion).toEqual(SAMPLE);
     });
 
     it('preserves diversion through JSON serialization', () => {

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -113,4 +113,25 @@ describe('CallSession domain', () => {
       expect(cs.recordingState).toEqual(RECORDING_STATE.PAUSED);
     });
   });
+
+  describe('diversion field', () => {
+    const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
+
+    it('defaults to an empty array when not provided', () => {
+      const cs = new CallSession({} as any);
+      expect(cs.diversion).toEqual([]);
+    });
+
+    it('preserves diversion through updateFrom', () => {
+      const cs = new CallSession({ callId: 'a', diversion: SAMPLE } as any);
+      const next = new CallSession({ callId: 'a' } as any);
+      next.updateFrom(cs);
+      expect(next.diversion).toEqual(SAMPLE);
+    });
+
+    it('preserves diversion through JSON serialization', () => {
+      const cs = new CallSession({ callId: 'a', diversion: SAMPLE } as any);
+      expect(stringify(cs).diversion).toEqual(SAMPLE);
+    });
+  });
 });

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -265,6 +265,7 @@ export type PeerConnection = RTCPeerConnection & {
 export type WazoSession = (Invitation | Inviter) & {
   remoteTag?: any;
   callId?: string;
+  diversion?: string[];
 };
 
 export type WazoTransport = Transport & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export { type Device } from './domain/Device/Device';
 export { default as DebugDevice } from './domain/Device/DebugDevice';
 export { default as Checker } from './checker/Checker';
 export { default as ApiRequester } from './utils/api-requester';
+export { parseDiversionHeader, type DivertedBy } from './utils/sip-diversion';
 export { type DirectorySource as Source, type DirectorySources as Sources } from './domain/DirectorySource';
 export { type DirectorySource, type DirectorySources } from './domain/DirectorySource';
 export {

--- a/src/utils/__tests__/sip-diversion.test.ts
+++ b/src/utils/__tests__/sip-diversion.test.ts
@@ -77,11 +77,4 @@ describe('parseDiversionHeader', () => {
     expect(parseDiversionHeader('not a sip uri')).toBeNull();
     expect(parseDiversionHeader('')).toBeNull();
   });
-
-  it('handles addr-spec without angle brackets', () => {
-    expect(parseDiversionHeader('sip:1001@wazo.example;reason=unconditional')).toEqual({
-      number: '1001',
-      reason: 'unconditional',
-    });
-  });
 });

--- a/src/utils/__tests__/sip-diversion.test.ts
+++ b/src/utils/__tests__/sip-diversion.test.ts
@@ -1,0 +1,87 @@
+import { parseDiversionHeader } from '../sip-diversion';
+
+describe('parseDiversionHeader', () => {
+  it('parses a quoted name-addr with reason', () => {
+    expect(
+      parseDiversionHeader('"Alice" <sip:1001@wazo.example>;reason=unconditional'),
+    ).toEqual({
+      number: '1001',
+      name: 'Alice',
+      reason: 'unconditional',
+    });
+  });
+
+  it('parses an unquoted display name', () => {
+    expect(
+      parseDiversionHeader('Alice Smith <sip:1001@wazo.example>;reason=user-busy'),
+    ).toEqual({
+      number: '1001',
+      name: 'Alice Smith',
+      reason: 'user-busy',
+    });
+  });
+
+  it('parses a bare addr-spec without display name', () => {
+    expect(
+      parseDiversionHeader('<sip:1001@wazo.example>;reason=no-answer'),
+    ).toEqual({
+      number: '1001',
+      reason: 'no-answer',
+    });
+  });
+
+  it('parses multiple parameters including a quoted value', () => {
+    expect(
+      parseDiversionHeader('"Bob" <sip:1002@wazo.example>;reason="time-of-day";privacy=off;counter=2'),
+    ).toEqual({
+      number: '1002',
+      name: 'Bob',
+      reason: 'time-of-day',
+      privacy: 'off',
+    });
+  });
+
+  it('preserves privacy=full', () => {
+    expect(
+      parseDiversionHeader('"Bob" <sip:1002@wazo.example>;privacy=full;reason=unconditional'),
+    ).toEqual({
+      number: '1002',
+      name: 'Bob',
+      reason: 'unconditional',
+      privacy: 'full',
+    });
+  });
+
+  it('parses an anonymous URI', () => {
+    expect(
+      parseDiversionHeader('<sip:anonymous@anonymous.invalid>;privacy=full;reason=unconditional'),
+    ).toEqual({
+      number: 'anonymous',
+      reason: 'unconditional',
+      privacy: 'full',
+    });
+  });
+
+  it('handles parameter names case-insensitively', () => {
+    expect(
+      parseDiversionHeader('"Alice" <sip:1001@wazo.example>;Reason=UNCONDITIONAL;PRIVACY=Off'),
+    ).toEqual({
+      number: '1001',
+      name: 'Alice',
+      reason: 'UNCONDITIONAL',
+      privacy: 'Off',
+    });
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseDiversionHeader('not a sip uri')).toBeNull();
+    expect(parseDiversionHeader('')).toBeNull();
+  });
+
+  it('handles addr-spec without angle brackets', () => {
+    expect(parseDiversionHeader('sip:1001@wazo.example;reason=unconditional')).toEqual({
+      number: '1001',
+      reason: 'unconditional',
+    });
+  });
+});

--- a/src/utils/sip-diversion.ts
+++ b/src/utils/sip-diversion.ts
@@ -1,0 +1,97 @@
+export type DivertedBy = {
+  number: string;
+  name?: string;
+  reason?: string;
+  privacy?: string;
+};
+
+const splitOutsideQuotesAndAngles = (input: string): string[] => {
+  const parts: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let angleDepth = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+    const prev = i > 0 ? input[i - 1] : '';
+    if (ch === '"' && prev !== '\\') {
+      inQuotes = !inQuotes;
+      current += ch;
+    } else if (!inQuotes && ch === '<') {
+      angleDepth += 1;
+      current += ch;
+    } else if (!inQuotes && ch === '>') {
+      angleDepth = Math.max(0, angleDepth - 1);
+      current += ch;
+    } else if (ch === ';' && !inQuotes && angleDepth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length) parts.push(current);
+  return parts;
+};
+
+const stripQuotes = (input: string): string => {
+  const trimmed = input.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+  }
+  return trimmed;
+};
+
+const extractUserFromUri = (uri: string): string | null => {
+  const match = uri.match(/^\s*sips?:([^@>;?\s]+)@/i);
+  return match ? match[1] : null;
+};
+
+/**
+ * Parse a single SIP `Diversion` header value (RFC 5806 / draft-levy-sip-diversion).
+ *
+ * Returns the forwarder identity and selected parameters, or `null` if the
+ * input does not contain a parseable SIP URI. A `Diversion` field can hold
+ * multiple values (a forwarding chain, most-recent-first); call this once per
+ * value if the chain is needed.
+ */
+export const parseDiversionHeader = (raw: string): DivertedBy | null => {
+  if (!raw) return null;
+
+  const segments = splitOutsideQuotesAndAngles(raw);
+  if (segments.length === 0) return null;
+
+  const [addrPart, ...paramParts] = segments;
+  const addr = addrPart.trim();
+  if (!addr) return null;
+
+  let displayName: string | undefined;
+  let uri: string;
+
+  const angleStart = addr.indexOf('<');
+  if (angleStart !== -1) {
+    const angleEnd = addr.indexOf('>', angleStart);
+    if (angleEnd === -1) return null;
+    const namePart = addr.slice(0, angleStart).trim();
+    if (namePart) displayName = stripQuotes(namePart);
+    uri = addr.slice(angleStart + 1, angleEnd).trim();
+  } else {
+    uri = addr;
+  }
+
+  const number = extractUserFromUri(uri);
+  if (!number) return null;
+
+  const result: DivertedBy = { number };
+  if (displayName) result.name = displayName;
+
+  paramParts.forEach((part) => {
+    const eq = part.indexOf('=');
+    if (eq === -1) return;
+    const key = part.slice(0, eq).trim().toLowerCase();
+    const value = stripQuotes(part.slice(eq + 1).trim());
+    if (key === 'reason') result.reason = value;
+    else if (key === 'privacy') result.privacy = value;
+  });
+
+  return result;
+};

--- a/src/utils/sip-diversion.ts
+++ b/src/utils/sip-diversion.ts
@@ -1,49 +1,10 @@
+import { Grammar } from 'sip.js/lib/grammar/grammar';
+
 export type DivertedBy = {
   number: string;
   name?: string;
   reason?: string;
   privacy?: string;
-};
-
-const splitOutsideQuotesAndAngles = (input: string): string[] => {
-  const parts: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  let angleDepth = 0;
-  for (let i = 0; i < input.length; i += 1) {
-    const ch = input[i];
-    const prev = i > 0 ? input[i - 1] : '';
-    if (ch === '"' && prev !== '\\') {
-      inQuotes = !inQuotes;
-      current += ch;
-    } else if (!inQuotes && ch === '<') {
-      angleDepth += 1;
-      current += ch;
-    } else if (!inQuotes && ch === '>') {
-      angleDepth = Math.max(0, angleDepth - 1);
-      current += ch;
-    } else if (ch === ';' && !inQuotes && angleDepth === 0) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  if (current.length) parts.push(current);
-  return parts;
-};
-
-const stripQuotes = (input: string): string => {
-  const trimmed = input.trim();
-  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
-  }
-  return trimmed;
-};
-
-const extractUserFromUri = (uri: string): string | null => {
-  const match = uri.match(/^\s*sips?:([^@>;?\s]+)@/i);
-  return match ? match[1] : null;
 };
 
 /**
@@ -54,44 +15,26 @@ const extractUserFromUri = (uri: string): string | null => {
  * multiple values (a forwarding chain, most-recent-first); call this once per
  * value if the chain is needed.
  */
+const unquote = (value: string | null | undefined): string | undefined => {
+  if (!value) return undefined;
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\(.)/g, '$1');
+  }
+  return value;
+};
+
 export const parseDiversionHeader = (raw: string): DivertedBy | null => {
   if (!raw) return null;
+  const header = Grammar.nameAddrHeaderParse(raw);
+  if (!header) return null;
 
-  const segments = splitOutsideQuotesAndAngles(raw);
-  if (segments.length === 0) return null;
+  const reason = unquote(header.getParam('reason'));
+  const privacy = unquote(header.getParam('privacy'));
 
-  const [addrPart, ...paramParts] = segments;
-  const addr = addrPart.trim();
-  if (!addr) return null;
-
-  let displayName: string | undefined;
-  let uri: string;
-
-  const angleStart = addr.indexOf('<');
-  if (angleStart !== -1) {
-    const angleEnd = addr.indexOf('>', angleStart);
-    if (angleEnd === -1) return null;
-    const namePart = addr.slice(0, angleStart).trim();
-    if (namePart) displayName = stripQuotes(namePart);
-    uri = addr.slice(angleStart + 1, angleEnd).trim();
-  } else {
-    uri = addr;
-  }
-
-  const number = extractUserFromUri(uri);
-  if (!number) return null;
-
-  const result: DivertedBy = { number };
-  if (displayName) result.name = displayName;
-
-  paramParts.forEach((part) => {
-    const eq = part.indexOf('=');
-    if (eq === -1) return;
-    const key = part.slice(0, eq).trim().toLowerCase();
-    const value = stripQuotes(part.slice(eq + 1).trim());
-    if (key === 'reason') result.reason = value;
-    else if (key === 'privacy') result.privacy = value;
-  });
-
-  return result;
+  return {
+    number: header.uri.user ?? '',
+    ...(header.displayName ? { name: header.displayName } : {}),
+    ...(reason ? { reason } : {}),
+    ...(privacy ? { privacy } : {}),
+  };
 };

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2215,6 +2215,13 @@ export default class WebRTCClient extends Emitter {
       session.delegate = {};
     }
 
+    if (session instanceof Invitation) {
+      const diversion = session.request.getHeaders('Diversion');
+      if (diversion?.length) {
+        session.diversion = diversion;
+      }
+    }
+
     session.delegate.onSessionDescriptionHandler = (sdh: SessionDescriptionHandler & { on: (type: string, e: any) => void }) => {
       sdh.on('error', (e: any) => {
         this.eventEmitter.emit(ON_ERROR, e);


### PR DESCRIPTION
Adding SIP header `diversion` in call session.

- Read SIP header `diversion`
- Add utility function to parse the header string and return the latest forwarder
- Extends types


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIP session setup and call-session creation to capture and persist new header data; low algorithmic complexity, but it affects call signaling metadata on incoming invites.
> 
> **Overview**
> Adds support for the SIP `Diversion` header by capturing `Diversion` values on incoming `Invitation`s in `WebRTCClient._setupSession` and threading them through `WazoSession` into `WebRTCPhone._createCallSession` and the `CallSession` model (new optional `diversion?: string[]`).
> 
> Introduces and exports `parseDiversionHeader` (with tests) to parse a single Diversion header value into a `DivertedBy` object, and adds unit tests to ensure `diversion` is propagated, preserved via `updateFrom`, and survives JSON serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e01c4adb9dda22caa5eb4c4bb453956f731c07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->