### PR TITLE
[ITEM-311] Guard delayed sip.js calls against bad session state

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -246,6 +246,96 @@ describe('WebRTC client', () => {
     });
   });
 });
+describe('ICE reconnect reinvite guard', () => {
+  let reinviteSpy: jest.SpyInstance;
+  const spies: jest.SpyInstance[] = [];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    reinviteSpy = jest.spyOn(client, 'reinvite').mockResolvedValue(undefined as any);
+    spies.push(
+      jest.spyOn(client as any, '_setupMedias').mockResolvedValue(undefined),
+      jest.spyOn(client, 'updateRemoteStream').mockImplementation(() => {}),
+      jest.spyOn(client, 'storeSipSession').mockImplementation(() => {}),
+      jest.spyOn(client as any, '_startSendingStats').mockImplementation(() => {}),
+      jest.spyOn(client, 'isConference').mockReturnValue(false),
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    spies.forEach(s => s.mockRestore());
+    spies.length = 0;
+    reinviteSpy.mockRestore();
+    (client as any).mediaConnectedSessions = {};
+    (client as any).iceReconnectAttempts = {};
+  });
+
+  const buildSession = (sessionId: string, state: SessionState) => {
+    const pc = {
+      connectionState: 'new',
+      onconnectionstatechange: null as (() => void) | null,
+      iceConnectionState: 'new',
+      oniceconnectionstatechange: null as (() => void) | null,
+      addEventListener: jest.fn(),
+    };
+    const remoteStream = {
+      getTracks: jest.fn(() => []),
+      getAudioTracks: jest.fn(() => []),
+      getVideoTracks: jest.fn(() => []),
+      onaddtrack: null,
+    };
+    const session = {
+      state,
+      sessionDescriptionHandler: { peerConnection: pc, remoteMediaStream: remoteStream },
+      sessionDescriptionHandlerModifiersReInvite: [],
+    } as any;
+    spies.push(jest.spyOn(client, 'getSipSessionId').mockReturnValue(sessionId));
+    return { session, pc };
+  };
+
+  it('reinvites when the session is still Established when the timer fires', async () => {
+    const { session, pc } = buildSession('ice-1', SessionState.Established);
+
+    // eslint-disable-next-line no-underscore-dangle
+    await (client as any)._onAccepted(session, undefined, false, true);
+
+    (pc as any).iceConnectionState = 'disconnected';
+    pc.oniceconnectionstatechange!();
+    jest.runAllTimers();
+
+    expect(reinviteSpy).toHaveBeenCalledWith(session, null, false, false, true);
+  });
+
+  it('skips the reinvite when the session has Terminated before the timer fires', async () => {
+    const { session, pc } = buildSession('ice-2', SessionState.Established);
+
+    // eslint-disable-next-line no-underscore-dangle
+    await (client as any)._onAccepted(session, undefined, false, true);
+
+    (pc as any).iceConnectionState = 'disconnected';
+    pc.oniceconnectionstatechange!();
+    session.state = SessionState.Terminated;
+    jest.runAllTimers();
+
+    expect(reinviteSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips the reinvite when the session is Terminating when the timer fires', async () => {
+    const { session, pc } = buildSession('ice-3', SessionState.Established);
+
+    // eslint-disable-next-line no-underscore-dangle
+    await (client as any)._onAccepted(session, undefined, false, true);
+
+    (pc as any).iceConnectionState = 'disconnected';
+    pc.oniceconnectionstatechange!();
+    session.state = SessionState.Terminating;
+    jest.runAllTimers();
+
+    expect(reinviteSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('changeAudioInputDevice', () => {
   const defaultId = 'default';
   const deviceId = 'device1';

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -358,6 +358,16 @@ export default class WebRTCPhone extends Emitter implements Phone {
     });
     // Have to send the message after a delay due to latency to update the remote peer
     setTimeout(() => {
+      // Guard against the session not being in Established state when the timer fires:
+      // sip.js rejects message() unless the session is Established. On slow networks/devices the preceding
+      // re-INVITE may still be in Establishing, or the session may already be Terminated/Terminating.
+      if (!sipSession || sipSession.state !== SessionState.Established) {
+        logger.info('Reinvite track-update message skipped, session not Established', {
+          id: callSession ? callSession.getId() : null,
+          state: sipSession?.state,
+        });
+        return;
+      }
       this.sendMessage(sipSession, JSON.stringify({
         type: MESSAGE_TYPE_SIGNAL,
         content: {

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -1,3 +1,5 @@
+import { SessionState } from 'sip.js/lib/api/session-state';
+
 import WebRTCPhone from '../WebRTCPhone';
 import CallSession from '../../CallSession';
 
@@ -110,6 +112,87 @@ describe('WebRTCPhone._createCallSession diversion', () => {
     const cs = phone._createCallSession(sipSession);
 
     expect(cs.diversion).toBeUndefined();
+  });
+});
+/* eslint-enable no-underscore-dangle */
+
+/* eslint-disable no-underscore-dangle */
+describe('WebRTCPhone._sendReinviteMessage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createMessageMockClient = (sessions: Record<string, any> = {}) => ({
+    ...createMockClient(sessions),
+    sendMessage: jest.fn(),
+  });
+
+  it('sends the track-update message when the session is Established when the timer fires', () => {
+    const sipSession = { id: 'session-1', state: SessionState.Established } as any;
+    const client = createMessageMockClient({ 'session-1': sipSession });
+    const phone = createPhone(client);
+    const callSession = new CallSession({ callId: 'session-1', sipCallId: 'session-1' } as any);
+
+    phone._sendReinviteMessage(callSession, true);
+    jest.runAllTimers();
+
+    expect(client.sendMessage).toHaveBeenCalledTimes(1);
+    const [calledSession, body] = client.sendMessage.mock.calls[0];
+    expect(calledSession).toBe(sipSession);
+    expect(JSON.parse(body).content.update).toBe('upgrade');
+  });
+
+  it('skips the message when the session is not yet Established when the timer fires', () => {
+    const sipSession = { id: 'session-1', state: SessionState.Establishing } as any;
+    const client = createMessageMockClient({ 'session-1': sipSession });
+    const phone = createPhone(client);
+    const callSession = new CallSession({ callId: 'session-1', sipCallId: 'session-1' } as any);
+
+    phone._sendReinviteMessage(callSession, true);
+    jest.runAllTimers();
+
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips the message when the session is already Terminated when the timer fires', () => {
+    const sipSession = { id: 'session-1', state: SessionState.Terminated } as any;
+    const client = createMessageMockClient({ 'session-1': sipSession });
+    const phone = createPhone(client);
+    const callSession = new CallSession({ callId: 'session-1', sipCallId: 'session-1' } as any);
+
+    phone._sendReinviteMessage(callSession, false);
+    jest.runAllTimers();
+
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips the message when no sip session can be resolved', () => {
+    const client = createMessageMockClient({});
+    const phone = createPhone(client);
+    phone.fallbackToFirstSipSession = false;
+    const callSession = new CallSession({ callId: 'unknown', sipCallId: 'unknown' } as any);
+
+    phone._sendReinviteMessage(callSession, false);
+    jest.runAllTimers();
+
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips the message when the session moves to Terminated after scheduling', () => {
+    const sipSession = { id: 'session-1', state: SessionState.Established } as any;
+    const client = createMessageMockClient({ 'session-1': sipSession });
+    const phone = createPhone(client);
+    const callSession = new CallSession({ callId: 'session-1', sipCallId: 'session-1' } as any);
+
+    phone._sendReinviteMessage(callSession, true);
+    sipSession.state = SessionState.Terminated;
+    jest.runAllTimers();
+
+    expect(client.sendMessage).not.toHaveBeenCalled();
   });
 });
 /* eslint-enable no-underscore-dangle */

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -2390,7 +2390,18 @@ export default class WebRTCClient extends Emitter {
             const isConference = this.isConference(currentSessionId);
 
             // The reinvite will trigger a new offer/answer, and oniceconnectionstatechange will be called again.
-            setTimeout(() => { this.reinvite(session, null, isConference, false, true); }, this.iceReconnectDelay);
+            setTimeout(() => {
+              // Guard against the session being torn down between scheduling and firing:
+              // sip.js rejects invite() on a Terminated/Terminating session as an unhandled promise.
+              if (session.state === SessionState.Terminated || session.state === SessionState.Terminating) {
+                logger.info('ICE reconnect reinvite skipped, session no longer active', {
+                  sessionId: currentSessionId,
+                  state: session.state,
+                });
+                return;
+              }
+              this.reinvite(session, null, isConference, false, true);
+            }, this.iceReconnectDelay);
           } else {
             logger.warn('ICE reconnection failed after max attempts', {
               sessionId: currentSessionId,


### PR DESCRIPTION
## Summary

Two `setTimeout`-scheduled sip.js operations rejected as unhandled promises when the session moved out of the expected state between scheduling and firing. Both call sites are now guarded with a `SessionState` check and log when skipped.

- **`src/web-rtc-client.ts`** (ICE-reconnect reinvite): on `iceConnectionState === 'disconnected'` we schedule `this.reinvite(session, ...)` after `iceReconnectDelay`. If the session was torn down in that window (background, network loss, server cancel), `sip.js` rejects `session.invite()` because the state is `Terminated`/`Terminating`.
  - Sentry: [WAZO-MOBILE-3A2](https://wazo.sentry.io/issues/WAZO-MOBILE-3A2) — `Invalid session state Terminated`, 27 occurrences, 21 users.

- **`src/domain/Phone/WebRTCPhone.ts`** (`_sendReinviteMessage`): 2.5s after a video upgrade/downgrade we send a `MESSAGE_TYPE_SIGNAL` to inform the peer. On slow networks/devices the re-INVITE itself may still be in `Establishing` when the timer fires, and `sip.js` rejects `session.message()`.
  - Sentry: [WAZO-MOBILE-2WZ](https://wazo.sentry.io/issues/WAZO-MOBILE-2WZ) — `Invalid session state Establishing`, 169 occurrences, 47 users.

Most-affected fleet: Samsung Galaxy A53 (SM-A536B) on Android 16, where SIP establishment is slow enough to widen both race windows.

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm lint` passes (verified locally)
- [ ] Manual: trigger ICE disconnect during a call, confirm the skip log appears when the call was already hung up before the timer fired
- [ ] Manual: perform a video upgrade on a slow network, confirm no unhandled rejection and that the skip log fires if the re-INVITE is still pending at 2.5s
- [ ] Watch Sentry WAZO-MOBILE-3A2 and WAZO-MOBILE-2WZ in the next release for occurrence drop-off