### PR TITLE
[ITEM-332] feat(api): add ignoreErrors to skip logging expected statuses

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -274,7 +274,8 @@ export default ((client: ApiRequester, baseUrl: string) => ({
 
   getProviders: (userUuid: UUID): Promise<any> => client.get(`${baseUrl}/users/${userUuid}/external`),
 
-  getProviderToken: (userUuid: UUID, provider: string): Promise<string> => client.get(`${baseUrl}/users/${userUuid}/external/${provider}`),
+  // External provider may not be linked for this user — a 404 is expected and not a real error.
+  getProviderToken: (userUuid: UUID, provider: string): Promise<string> => client.get({ path: `${baseUrl}/users/${userUuid}/external/${provider}`, ignoreErrors: [404] }),
 
   getProviderAuthUrl: (userUuid: UUID, provider: string): Promise<string> => client.post(`${baseUrl}/users/${userUuid}/external/${provider}`, {}),
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -275,7 +275,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   getProviders: (userUuid: UUID): Promise<any> => client.get(`${baseUrl}/users/${userUuid}/external`),
 
   // External provider may not be linked for this user — a 404 is expected and not a real error.
-  getProviderToken: (userUuid: UUID, provider: string): Promise<string> => client.get({ path: `${baseUrl}/users/${userUuid}/external/${provider}`, ignoreErrors: [404] }),
+  getProviderToken: (userUuid: UUID, provider: string): Promise<string> => client.get({ path: `${baseUrl}/users/${userUuid}/external/${provider}`, ignoreStatuses: [404] }),
 
   getProviderAuthUrl: (userUuid: UUID, provider: string): Promise<string> => client.post(`${baseUrl}/users/${userUuid}/external/${provider}`, {}),
 

--- a/src/api/confd.ts
+++ b/src/api/confd.ts
@@ -79,7 +79,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
 
     try {
       // The external app may not be configured on the engine — a 404 is expected and not a real error.
-      return await client.get({ path: `${baseUrl}/${path}`, ignoreErrors: [404] }).then(ExternalApp.parse);
+      return await client.get({ path: `${baseUrl}/${path}`, ignoreStatuses: [404] }).then(ExternalApp.parse);
     } catch (e: any) {
       return null;
     }

--- a/src/api/confd.ts
+++ b/src/api/confd.ts
@@ -75,10 +75,11 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   getExternalApps: (userUuid: string): Promise<ExternalApp[]> => client.get(`${baseUrl}/users/${userUuid}/external/apps`).then(ExternalApp.parseMany),
 
   getExternalApp: async (userUuid: string, name: string): Promise<ExternalApp | null | undefined> => {
-    const url = `${baseUrl}/users/${userUuid}/external/apps/${name}?view=fallback`;
+    const path = `users/${userUuid}/external/apps/${name}?view=fallback`;
 
     try {
-      return await client.get(url).then(ExternalApp.parse);
+      // The external app may not be configured on the engine — a 404 is expected and not a real error.
+      return await client.get({ path: `${baseUrl}/${path}`, ignoreErrors: [404] }).then(ExternalApp.parse);
     } catch (e: any) {
       return null;
     }

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -47,8 +47,11 @@ export default ((client: ApiRequester, baseUrl: string) => ({
 
   removeFavorite: (source: string, sourceId: string): Promise<void> => client.delete(`${baseUrl}/directories/favorites/${source}/${sourceId}`),
 
-  fetchOffice365Source: (context: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, {
-    backend: 'office365',
+  // The directory source may not be configured on the engine — a 404 is expected and not a real error.
+  fetchOffice365Source: (context: string): Promise<DirectorySources> => client.get({
+    path: `${baseUrl}/directories/${context}/sources`,
+    body: { backend: 'office365' },
+    ignoreErrors: [404],
   }),
 
   fetchOffice365Contacts: async (source: DirectorySource, queryParams?: SearchableQueryParams): Promise<Contact[]> => {
@@ -59,8 +62,11 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     return client.get(`${baseUrl}/backends/office365/sources/${source.uuid}/contacts`, queryParams).then((response: any) => Contact.parseManyOffice365(response.items, source));
   },
 
-  fetchWazoSource: (context: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, {
-    backend: 'wazo',
+  // The directory source may not be configured on the engine — a 404 is expected and not a real error.
+  fetchWazoSource: (context: string): Promise<DirectorySources> => client.get({
+    path: `${baseUrl}/directories/${context}/sources`,
+    body: { backend: 'wazo' },
+    ignoreErrors: [404],
   }),
 
   // Can be used with `queryParams = { uuid: uuid1, uuid2 }` to fetch multiple contacts
@@ -79,8 +85,11 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     return client.get(`${baseUrl}/backends/wazo/sources/${source.uuid}/contacts`, queryParams).then((response: any) => parser(response, source));
   },
 
-  fetchGoogleSource: (context: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, {
-    backend: 'google',
+  // The directory source may not be configured on the engine — a 404 is expected and not a real error.
+  fetchGoogleSource: (context: string): Promise<DirectorySources> => client.get({
+    path: `${baseUrl}/directories/${context}/sources`,
+    body: { backend: 'google' },
+    ignoreErrors: [404],
   }),
 
   fetchGoogleContacts: async (source: DirectorySource, queryParams?: SearchableQueryParams): Promise<Contact[]> => {
@@ -91,8 +100,11 @@ export default ((client: ApiRequester, baseUrl: string) => ({
     return client.get(`${baseUrl}/backends/google/sources/${source.uuid}/contacts`, queryParams).then((response: any) => Contact.parseManyGoogle(response.items, source));
   },
 
-  fetchConferenceSource: (context: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, {
-    backend: 'conference',
+  // The directory source may not be configured on the engine — a 404 is expected and not a real error.
+  fetchConferenceSource: (context: string): Promise<DirectorySources> => client.get({
+    path: `${baseUrl}/directories/${context}/sources`,
+    body: { backend: 'conference' },
+    ignoreErrors: [404],
   }),
 
   fetchSourcesFor: (context: string, backend: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, { backend }),

--- a/src/api/dird.ts
+++ b/src/api/dird.ts
@@ -51,7 +51,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   fetchOffice365Source: (context: string): Promise<DirectorySources> => client.get({
     path: `${baseUrl}/directories/${context}/sources`,
     body: { backend: 'office365' },
-    ignoreErrors: [404],
+    ignoreStatuses: [404],
   }),
 
   fetchOffice365Contacts: async (source: DirectorySource, queryParams?: SearchableQueryParams): Promise<Contact[]> => {
@@ -66,7 +66,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   fetchWazoSource: (context: string): Promise<DirectorySources> => client.get({
     path: `${baseUrl}/directories/${context}/sources`,
     body: { backend: 'wazo' },
-    ignoreErrors: [404],
+    ignoreStatuses: [404],
   }),
 
   // Can be used with `queryParams = { uuid: uuid1, uuid2 }` to fetch multiple contacts
@@ -89,7 +89,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   fetchGoogleSource: (context: string): Promise<DirectorySources> => client.get({
     path: `${baseUrl}/directories/${context}/sources`,
     body: { backend: 'google' },
-    ignoreErrors: [404],
+    ignoreStatuses: [404],
   }),
 
   fetchGoogleContacts: async (source: DirectorySource, queryParams?: SearchableQueryParams): Promise<Contact[]> => {
@@ -104,7 +104,7 @@ export default ((client: ApiRequester, baseUrl: string) => ({
   fetchConferenceSource: (context: string): Promise<DirectorySources> => client.get({
     path: `${baseUrl}/directories/${context}/sources`,
     body: { backend: 'conference' },
-    ignoreErrors: [404],
+    ignoreStatuses: [404],
   }),
 
   fetchSourcesFor: (context: string, backend: string): Promise<DirectorySources> => client.get(`${baseUrl}/directories/${context}/sources`, { backend }),

--- a/src/utils/__tests__/api-requester.test.ts
+++ b/src/utils/__tests__/api-requester.test.ts
@@ -288,7 +288,7 @@ describe('ignoreErrors option', () => {
   const apiErrorCalls = () => logSpy.mock.calls.filter(call => call[2] === 'API error');
 
   it('does not log an API error when status is in ignoreErrors', async () => {
-    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
     await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
 
@@ -296,7 +296,7 @@ describe('ignoreErrors option', () => {
   });
 
   it('still logs when the status is not in ignoreErrors', async () => {
-    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(500)) });
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(500)) });
 
     await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
 
@@ -304,7 +304,7 @@ describe('ignoreErrors option', () => {
   });
 
   it('logs as usual when ignoreErrors is not set', async () => {
-    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
     await expect(requester.call({ path, method })).rejects.toBeDefined();
 
@@ -312,7 +312,7 @@ describe('ignoreErrors option', () => {
   });
 
   it('does not affect a concurrent call without ignoreErrors', async () => {
-    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
     await Promise.allSettled([
       requester.call({ path, method, ignoreErrors: [404] }),

--- a/src/utils/__tests__/api-requester.test.ts
+++ b/src/utils/__tests__/api-requester.test.ts
@@ -259,7 +259,7 @@ describe('Handling 204 No Content responses', () => {
   });
 });
 
-describe('ignoreErrors option', () => {
+describe('ignoreStatuses option', () => {
   const makeFetchResponse = (status: number) => Promise.resolve({
     status,
     headers: { get: () => 'application/json' },
@@ -287,23 +287,23 @@ describe('ignoreErrors option', () => {
 
   const apiErrorCalls = () => logSpy.mock.calls.filter(call => call[2] === 'API error');
 
-  it('does not log an API error when status is in ignoreErrors', async () => {
+  it('does not log an API error when status is in ignoreStatuses', async () => {
     Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
-    await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
+    await expect(requester.call({ path, method, ignoreStatuses: [404] })).rejects.toBeDefined();
 
     expect(apiErrorCalls()).toHaveLength(0);
   });
 
-  it('still logs when the status is not in ignoreErrors', async () => {
+  it('still logs when the status is not in ignoreStatuses', async () => {
     Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(500)) });
 
-    await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
+    await expect(requester.call({ path, method, ignoreStatuses: [404] })).rejects.toBeDefined();
 
     expect(apiErrorCalls()).toHaveLength(1);
   });
 
-  it('logs as usual when ignoreErrors is not set', async () => {
+  it('logs as usual when ignoreStatuses is not set', async () => {
     Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
     await expect(requester.call({ path, method })).rejects.toBeDefined();
@@ -311,11 +311,11 @@ describe('ignoreErrors option', () => {
     expect(apiErrorCalls()).toHaveLength(1);
   });
 
-  it('does not affect a concurrent call without ignoreErrors', async () => {
+  it('does not affect a concurrent call without ignoreStatuses', async () => {
     Object.defineProperty(globalThis, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
 
     await Promise.allSettled([
-      requester.call({ path, method, ignoreErrors: [404] }),
+      requester.call({ path, method, ignoreStatuses: [404] }),
       requester.call({ path, method }),
     ]);
 

--- a/src/utils/__tests__/api-requester.test.ts
+++ b/src/utils/__tests__/api-requester.test.ts
@@ -1,4 +1,5 @@
 import ApiRequester from '../api-requester';
+import IssueReporter from '../../service/IssueReporter';
 
 const server = 'localhost';
 const path = 'auth';
@@ -255,6 +256,70 @@ describe('Handling 204 No Content responses', () => {
     }
 
     expect(error).toBeNull();
+  });
+});
+
+describe('ignoreErrors option', () => {
+  const makeFetchResponse = (status: number) => Promise.resolve({
+    status,
+    headers: { get: () => 'application/json' },
+    json: () => Promise.resolve({ reason: 'oops' }),
+  } as any);
+
+  let requester: ApiRequester;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    requester = new ApiRequester({
+      server,
+      agent: null,
+      clientId: null,
+      token,
+      refreshTokenCallback: () => null,
+      fetchOptions: null,
+    });
+    logSpy = jest.spyOn(IssueReporter, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  const apiErrorCalls = () => logSpy.mock.calls.filter(call => call[2] === 'API error');
+
+  it('does not log an API error when status is in ignoreErrors', async () => {
+    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+
+    await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
+
+    expect(apiErrorCalls()).toHaveLength(0);
+  });
+
+  it('still logs when the status is not in ignoreErrors', async () => {
+    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(500)) });
+
+    await expect(requester.call({ path, method, ignoreErrors: [404] })).rejects.toBeDefined();
+
+    expect(apiErrorCalls()).toHaveLength(1);
+  });
+
+  it('logs as usual when ignoreErrors is not set', async () => {
+    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+
+    await expect(requester.call({ path, method })).rejects.toBeDefined();
+
+    expect(apiErrorCalls()).toHaveLength(1);
+  });
+
+  it('does not affect a concurrent call without ignoreErrors', async () => {
+    Object.defineProperty(global, 'fetch', { value: jest.fn(() => makeFetchResponse(404)) });
+
+    await Promise.allSettled([
+      requester.call({ path, method, ignoreErrors: [404] }),
+      requester.call({ path, method }),
+    ]);
+
+    expect(apiErrorCalls()).toHaveLength(1);
   });
 });
 

--- a/src/utils/api-requester.ts
+++ b/src/utils/api-requester.ts
@@ -24,7 +24,17 @@ type CallBody = Record<string, any> | null | undefined | string;
 type CallHeaders = { 'Wazo-Tenant'?: boolean | string | null, [key: string]: any } | null | undefined;
 type CallParser = ((...args: Array<any>) => any) | undefined;
 
-type CallParams = { path: string, body?: CallBody, headers?: CallHeaders, parse?: CallParser, firstCall?: boolean };
+type CallParams = {
+  path: string,
+  body?: CallBody,
+  headers?: CallHeaders,
+  parse?: CallParser,
+  firstCall?: boolean,
+  // Response statuses listed here won't be reported to the logger.
+  // The caller still receives the rejection — only the "API error" log line is skipped.
+  // Useful for endpoints that may legitimately fail (e.g. probing an optional feature).
+  ignoreErrors?: number[],
+};
 type CallHelpers = {
   // Signature 1: Single object argument
   (options: CallParams): Promise<any>;
@@ -171,6 +181,7 @@ export default class ApiRequester {
     headers = null,
     parse = ApiRequester.defaultParser,
     firstCall = true,
+    ignoreErrors,
   }: CallParams & { method: Methods }): Promise<any> {
     const url = this.computeUrl(method, path, body);
     const newHeaders = this.getHeaders(headers);
@@ -228,7 +239,8 @@ export default class ApiRequester {
 
           const error = typeof err === 'string' ? exceptionClass.fromText(err, response.status) : exceptionClass.fromResponse(err, response.status);
 
-          if (this.shouldLogErrors) {
+          const isIgnoredStatus = Array.isArray(ignoreErrors) && ignoreErrors.includes(response.status);
+          if (this.shouldLogErrors && !isIgnoredStatus) {
             logger.error('API error', error);
           }
 

--- a/src/utils/api-requester.ts
+++ b/src/utils/api-requester.ts
@@ -33,7 +33,7 @@ type CallParams = {
   // Response statuses listed here won't be reported to the logger.
   // The caller still receives the rejection — only the "API error" log line is skipped.
   // Useful for endpoints that may legitimately fail (e.g. probing an optional feature).
-  ignoreErrors?: number[],
+  ignoreStatuses?: number[],
 };
 type CallHelpers = {
   // Signature 1: Single object argument
@@ -181,7 +181,7 @@ export default class ApiRequester {
     headers = null,
     parse = ApiRequester.defaultParser,
     firstCall = true,
-    ignoreErrors,
+    ignoreStatuses = [],
   }: CallParams & { method: Methods }): Promise<any> {
     const url = this.computeUrl(method, path, body);
     const newHeaders = this.getHeaders(headers);
@@ -239,8 +239,7 @@ export default class ApiRequester {
 
           const error = typeof err === 'string' ? exceptionClass.fromText(err, response.status) : exceptionClass.fromResponse(err, response.status);
 
-          const isIgnoredStatus = Array.isArray(ignoreErrors) && ignoreErrors.includes(response.status);
-          if (this.shouldLogErrors && !isIgnoredStatus) {
+          if (this.shouldLogErrors && !ignoreStatuses.includes(response.status)) {
             logger.error('API error', error);
           }
 


### PR DESCRIPTION
## Summary

- Add optional `ignoreErrors: number[]` to `CallParams` in `ApiRequester`. When the response status is in the list, the `"API error"` log line is skipped while the rejection still propagates to the caller. No shared-state mutation, so concurrent calls are unaffected (the key limitation of the existing `disableErrorLogging()` global toggle).
- Apply `ignoreErrors: [404]` to endpoints that may legitimately 404 when an optional feature isn't configured on the engine:
  - `confd.getExternalApp`
  - `auth.getProviderToken`
  - `dird.fetchWazoSource`, `fetchGoogleSource`, `fetchOffice365Source`, `fetchConferenceSource`

## Motivation

Consumers were forced to flip the requester-wide `disable/enableErrorLogging()` flag to avoid flooding remote logs with expected 404s from optional integrations. That approach also silenced any concurrent SDK call landing in the same window. With this change, the SDK knows which of its endpoints may fail by design and stops logging only those — no wrapper needed at the call site.

## Test plan

- [x] `pnpm jest` — 291 tests pass, including 4 new ones in `src/utils/__tests__/api-requester.test.ts`:
  - 404 suppressed when listed
  - 500 still logs when only 404 is listed
  - default behavior unchanged
  - concurrent call without `ignoreErrors` still logs (regression guard vs. the global toggle)
- [x] `pnpm typecheck`
- [x] `pnpm lint`