### PR TITLE
fix(call-session): prevent sipSession cycle in serializers and copies

### DIFF
--- a/src/domain/CallSession.ts
+++ b/src/domain/CallSession.ts
@@ -333,7 +333,13 @@ export default class CallSession {
   }
 
   updateFrom(session: CallSession) {
-    updateFrom(this, session);
+    // `sipSession` is a SIP.js runtime handle owned by WebRTCPhone. It carries
+    // back-references (event emitters, dialogs) that form cycles when copied
+    // between CallSession instances and can crash any walker without a cycle
+    // guard. The current instance keeps its own sipSession; never propagate it.
+    const safeSource: any = { ...session };
+    delete safeSource.sipSession;
+    updateFrom(this, safeSource);
   }
 
   separateDisplayName(): {
@@ -362,7 +368,14 @@ export default class CallSession {
   }
 
   static newFrom(callSession: CallSession) {
-    return newFrom(callSession, CallSession);
+    // Strip `sipSession` before copying (see updateFrom) then re-attach the
+    // original reference so the new instance still points at the live SIP.js
+    // session without going through a generic property copy.
+    const safeSource: any = { ...callSession };
+    delete safeSource.sipSession;
+    const next = newFrom(safeSource, CallSession);
+    next.sipSession = callSession.sipSession;
+    return next;
   }
 
   // Retro-compatibility: `answered` was a boolean before. We can reproduce the behaviour with a getter/setter
@@ -375,8 +388,11 @@ export default class CallSession {
   }
 
   toJSON() {
-    const jsonObj = { ...this,
-    };
+    // Exclude `sipSession` from JSON output: it is a SIP.js Invitation/Inviter
+    // with internal back-references and event emitters that crash serializers
+    // (JSON.stringify, Sentry context, redux-logger…) on circular structures.
+    const jsonObj: any = { ...this };
+    delete jsonObj.sipSession;
     jsonObj.answered = this.answered;
     return jsonObj;
   }

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -126,7 +126,7 @@ describe('CallSession domain', () => {
     it('toJSON omits sipSession entirely', () => {
       const cs = new CallSession({ callId: 'a', sipCallId: 'b' } as any);
       cs.sipSession = buildCyclicSipSession(cs);
-      const json = cs.toJSON() as any;
+      const json = cs.toJSON();
       expect(json.sipSession).toBeUndefined();
     });
 
@@ -134,14 +134,15 @@ describe('CallSession domain', () => {
       const cs = new CallSession({ callId: 'a', sipCallId: 'b' } as any);
       cs.sipSession = buildCyclicSipSession(cs);
       expect(() => JSON.stringify(cs)).not.toThrow();
-      expect(JSON.parse(JSON.stringify(cs)).sipSession).toBeUndefined();
+      const serialized = JSON.stringify(cs);
+      expect(serialized).not.toContain('sipSession');
     });
 
     it('toJSON still includes the answered getter value', () => {
       const cs = new CallSession({ callId: 'a' } as any);
       cs.answered = true;
       cs.sipSession = { id: 'sip-1' } as any;
-      const json = cs.toJSON() as any;
+      const json = cs.toJSON();
       expect(json.answered).toBe(true);
       expect(json.sipSession).toBeUndefined();
     });

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -114,6 +114,76 @@ describe('CallSession domain', () => {
     });
   });
 
+  describe('sipSession handling (BUG-320 / ITEM-350)', () => {
+    // Builds a fake sipSession with a cycle back to its owning CallSession,
+    // mimicking what SIP.js does via event emitters / dialog references.
+    const buildCyclicSipSession = (owner: CallSession) => {
+      const fakeSipSession: any = { id: 'sip-1', state: 'Established' };
+      fakeSipSession.owner = owner; // cycle: sipSession.owner -> CallSession
+      return fakeSipSession;
+    };
+
+    it('toJSON omits sipSession entirely', () => {
+      const cs = new CallSession({ callId: 'a', sipCallId: 'b' } as any);
+      cs.sipSession = buildCyclicSipSession(cs);
+      const json = cs.toJSON() as any;
+      expect(json.sipSession).toBeUndefined();
+    });
+
+    it('toJSON does not throw on a CallSession with a circular sipSession', () => {
+      const cs = new CallSession({ callId: 'a', sipCallId: 'b' } as any);
+      cs.sipSession = buildCyclicSipSession(cs);
+      expect(() => JSON.stringify(cs)).not.toThrow();
+      expect(JSON.parse(JSON.stringify(cs)).sipSession).toBeUndefined();
+    });
+
+    it('toJSON still includes the answered getter value', () => {
+      const cs = new CallSession({ callId: 'a' } as any);
+      cs.answered = true;
+      cs.sipSession = { id: 'sip-1' } as any;
+      const json = cs.toJSON() as any;
+      expect(json.answered).toBe(true);
+      expect(json.sipSession).toBeUndefined();
+    });
+
+    it('updateFrom does not propagate sipSession from the source', () => {
+      const ownSipSession = { id: 'own' } as any;
+      const cs = new CallSession({ callId: 'a' } as any);
+      cs.sipSession = ownSipSession;
+
+      const other = new CallSession({ callId: 'a' } as any);
+      other.sipSession = buildCyclicSipSession(other);
+
+      cs.updateFrom(other);
+      // Current instance must keep its own sipSession reference.
+      expect(cs.sipSession).toBe(ownSipSession);
+    });
+
+    it('updateFrom does not loop when the source carries a circular sipSession', () => {
+      const cs = new CallSession({ callId: 'a' } as any);
+      const other = new CallSession({ callId: 'a', number: '8001' } as any);
+      other.sipSession = buildCyclicSipSession(other);
+      expect(() => cs.updateFrom(other)).not.toThrow();
+      // Non-sipSession fields are still copied across.
+      expect(cs.number).toBe('8001');
+    });
+
+    it('newFrom carries the source sipSession reference verbatim (no copy)', () => {
+      const src = new CallSession({ callId: 'a', number: '8001' } as any);
+      const sipSession = { id: 'sip-1' } as any;
+      src.sipSession = sipSession;
+      const copy = CallSession.newFrom(src);
+      expect(copy.sipSession).toBe(sipSession);
+      expect(copy.number).toBe('8001');
+    });
+
+    it('newFrom does not loop when the source carries a circular sipSession', () => {
+      const src = new CallSession({ callId: 'a' } as any);
+      src.sipSession = buildCyclicSipSession(src);
+      expect(() => CallSession.newFrom(src)).not.toThrow();
+    });
+  });
+
   describe('diversion field', () => {
     const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
 

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -1192,10 +1192,18 @@ export default class WebRTCClient extends Emitter {
           referId: this.getSipSessionId(result.newSession),
         });
         session.refer(result.newSession);
+        // Drop the consultation-leg reference once REFER is sent: holding it
+        // in the closure keeps a dead SIP.js session graph alive for any later
+        // walker (toJSON, logger, Sentry) to trip over.
+        result.newSession = null;
       },
       cancel: () => {
         this.hangup(result.newSession);
         this.unhold(session);
+        // Same reasoning as `complete`: after the consultation leg is hung up,
+        // null out the closure ref so a rejected/cancelled attended transfer
+        // doesn't leave a poisoned object graph reachable from the app side.
+        result.newSession = null;
       },
     };
     return result;


### PR DESCRIPTION
## Summary
- `CallSession.toJSON`, `updateFrom`, and `static newFrom` now strip the `sipSession` field (a SIP.js runtime handle that carries back-references via event emitters and dialogs) before copying / serializing. The instance's own `sipSession` is preserved; for `newFrom` the source's reference is re-attached after the safe copy.
- `WebRTCClient.atxfer().complete()` and `.cancel()` null `result.newSession` after use so the consultation-leg SIP session is not pinned by the closure after a completed or cancelled/rejected attended transfer.

## Why
After a failed attended transfer, the stale SIP.js consultation session was reachable from a `CallSession` via `sipSession`. Any later `JSON.stringify`, `updateFrom`, or `newFrom` on that CallSession walked the resulting cyclic object graph and saturated the JS thread (mqt_js at ~96% on Hermes), preventing UI render and ultimately triggering an OOM kill of the app. Logs from the customer bugreport (Samsung A54, `com.wazo.mdm` whitelabel) showed 70+ stack frames cycling through 7 distinct PCs inside the Hermes JS bundle under a single `JSIExecutor::callFunction` dispatch — the textbook signature of an unbounded sync recursion through the cycle.

Refs BUG-320 / ITEM-350.

## Test plan
- [x] `pnpm jest src/domain/__tests__/CallSession.test.ts` — 7 new regression tests under `sipSession handling (BUG-320 / ITEM-350)` covering: toJSON omits sipSession, toJSON doesn't throw on a circular sipSession, toJSON keeps the `answered` getter, updateFrom keeps the current instance's sipSession, updateFrom doesn't loop on a cyclic source, newFrom carries the source's sipSession reference verbatim, newFrom doesn't loop on a cyclic source.
- [x] `pnpm jest` — full suite, 32 suites / 298 tests passing.
- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [ ] Manual repro in wazo-mobile against this branch: attempt an attended transfer, reject the consultation leg, kill app, relaunch — JS thread should idle near 0% on the call screen.