### PR TITLE
fix(session): prevent toJson on circular keys

### DIFF
--- a/src/domain/Session.ts
+++ b/src/domain/Session.ts
@@ -15,6 +15,44 @@ const { jws } = KJUR;
 const swarmKey = <unknown>(KEYUTIL.getKey(swarmPublicKey)) as string;
 const MINIMUM_WAZO_ENGINE_VERSION_FOR_DEFAULT_CONTEXT = '19.08';
 
+// Clones a value to a JSON-safe form by dropping cyclic references. Used in
+// `toJSON` for fields whose shape is controlled by plugins (e.g. `metadata`)
+// to make sure a malformed extension can never cause `JSON.stringify(session)`
+// to throw or walk an unbounded graph. `seen` tracks the current path (entries
+// are removed on unwind) so only true back-references are dropped — shared,
+// non-cyclic references are preserved.
+const jsonSafeClone = (value: any, seen: WeakSet<any> = new WeakSet()): any => {
+  if (value === null || typeof value !== 'object' || value instanceof Date) {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return undefined;
+  }
+
+  seen.add(value);
+
+  let out: any;
+
+  if (Array.isArray(value)) {
+    out = value.map(item => jsonSafeClone(item, seen));
+  } else {
+    out = {};
+
+    Object.keys(value).forEach(key => {
+      const cloned = jsonSafeClone(value[key], seen);
+
+      if (cloned !== undefined) {
+        out[key] = cloned;
+      }
+    });
+  }
+
+  seen.delete(value);
+
+  return out;
+};
+
 type SessionMetadata = {
   jwt?: string;
   username?: string;
@@ -302,6 +340,12 @@ export default class Session {
   toJSON() {
     return {
       ...this,
+      // `metadata` is plugin-extensible (`[key: string]: any`). Clone it
+      // through a cycle-safe walker that drops circular branches so a
+      // plugin-introduced circular reference cannot cause downstream
+      // serializers (`JSON.stringify`, Sentry context, redux-logger…) to
+      // throw or hang on this Session.
+      metadata: jsonSafeClone(this.metadata),
       // Added `engineUuid` because of the getter, it won't be included in `JSON.stringify()` methods.
       engineUuid: this.stackUuid,
     };

--- a/src/domain/__tests__/IndirectTransfer.test.ts
+++ b/src/domain/__tests__/IndirectTransfer.test.ts
@@ -65,4 +65,41 @@ describe('Indirect transfer', () => {
       expect(isSource).toBeFalsy();
     });
   });
+
+  // IndirectTransfer's fields are all scalars (string IDs + status). The
+  // `update_from`/`new_from` helpers iterate keys once and copy references; they
+  // cannot loop on this shape. The tests below lock that contract in so any
+  // future field addition that breaks it (e.g. an object reference back to a
+  // CallSession) is caught here rather than at runtime in production.
+  describe('updateFrom and newFrom safety', () => {
+    it('updateFrom copies scalar fields from another IndirectTransfer', () => {
+      const a = new IndirectTransfer({ sourceId: 's-1', destinationId: 'd-1', status: 'starting' });
+      const b = new IndirectTransfer({ sourceId: 's-2', destinationId: 'd-2', status: 'answered', id: 'tr-1' });
+      a.updateFrom(b);
+      expect(a.sourceId).toBe('s-2');
+      expect(a.destinationId).toBe('d-2');
+      expect(a.status).toBe('answered');
+      expect(a.id).toBe('tr-1');
+    });
+
+    it('newFrom returns a new instance with the same scalar fields', () => {
+      const original = new IndirectTransfer({ sourceId: 's-1', destinationId: 'd-1', status: 'starting', id: 'tr-1' });
+      const copy = IndirectTransfer.newFrom(original);
+      expect(copy).not.toBe(original);
+      expect(copy).toEqual(original);
+    });
+
+    it('JSON.stringify of an IndirectTransfer round-trips cleanly', () => {
+      const transfer = new IndirectTransfer({ sourceId: 's-1', destinationId: 'd-1', status: 'starting', id: 'tr-1' });
+      expect(() => JSON.stringify(transfer)).not.toThrow();
+      // All fields are scalars: spreading the instance is equivalent to the
+      // JSON round-trip shape for plain-data classes like this one.
+      expect({ ...transfer }).toEqual({
+        sourceId: 's-1',
+        destinationId: 'd-1',
+        status: 'starting',
+        id: 'tr-1',
+      });
+    });
+  });
 });

--- a/src/domain/__tests__/Session.test.ts
+++ b/src/domain/__tests__/Session.test.ts
@@ -385,4 +385,69 @@ describe('Session domain', () => {
     expect(session.acl).toEqual(acl);
     console.warn = oldWarn;
   });
+
+  describe('toJSON cycle safety (metadata is plugin-extensible)', () => {
+    const makeSession = (metadata: any) => new Session({
+      token: 'tok-1',
+      uuid: 'u-1',
+      expiresAt: new Date('2030-01-01T00:00:00Z'),
+      stackUuid: 'stack-1',
+      metadata,
+    });
+
+    it('toJSON returns a `metadata` whose cyclic branches are dropped', () => {
+      const cyclicMetadata: any = { uuid: 'u-1', plugin: { name: 'evil' } };
+      cyclicMetadata.plugin.self = cyclicMetadata.plugin;
+      cyclicMetadata.plugin.root = cyclicMetadata;
+
+      const session = makeSession(cyclicMetadata);
+      const json: any = session.toJSON();
+
+      expect(json.metadata.uuid).toBe('u-1');
+      expect(json.metadata.plugin.name).toBe('evil');
+      expect('self' in json.metadata.plugin).toBe(false);
+      expect('root' in json.metadata.plugin).toBe(false);
+    });
+
+    it('toJSON preserves shared (non-cyclic) references', () => {
+      const shared = { foo: 'bar' };
+      const session = makeSession({ uuid: 'u-1', a: shared, b: shared });
+      const json: any = session.toJSON();
+
+      expect(json.metadata.a).toEqual({ foo: 'bar' });
+      expect(json.metadata.b).toEqual({ foo: 'bar' });
+    });
+
+    it('JSON.stringify(session) does not throw on cyclic metadata', () => {
+      const cyclicMetadata: any = { uuid: 'u-1' };
+      cyclicMetadata.self = cyclicMetadata;
+
+      const session = makeSession(cyclicMetadata);
+      expect(() => JSON.stringify(session)).not.toThrow();
+      // Inspect toJSON() directly — JSON.stringify calls it and feeds the
+      // result to its own serializer, so the shape returned here is exactly
+      // what downstream consumers receive.
+      const json: any = session.toJSON();
+      expect(json.metadata.uuid).toBe('u-1');
+      expect('self' in json.metadata).toBe(false);
+    });
+
+    it('toJSON preserves null/undefined metadata', () => {
+      const sessionNull = makeSession(null);
+      const sessionUndefined = makeSession(undefined);
+      expect((sessionNull.toJSON() as any).metadata).toBeNull();
+      expect((sessionUndefined.toJSON() as any).metadata).toBeUndefined();
+    });
+
+    it('toJSON keeps non-cyclic metadata structurally equal', () => {
+      const metadata = { uuid: 'u-1', tenants: [{ uuid: 't-1' }, { uuid: 't-2' }], extras: { foo: 'bar' } };
+      const session = makeSession(metadata);
+      expect((session.toJSON() as any).metadata).toEqual(metadata);
+    });
+
+    it('toJSON still exposes engineUuid getter value', () => {
+      const session = makeSession({ uuid: 'u-1' });
+      expect((session.toJSON() as any).engineUuid).toBe('stack-1');
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #863, same cycle-safety theme applied to `Session`.

`Session.toJSON()` clones `metadata` (plugin-extensible `[key: string]: any`) through a small cycle-safe walker, so a plugin-introduced circular ref can't make `JSON.stringify(session)` throw. Cyclic branches are dropped; shared non-cyclic refs are kept.

`IndirectTransfer` is all scalars and can't loop — no code change, just tests locking the contract.

Refs BUG-320 / ITEM-350.

### Test plan
- [x] `pnpm jest` — 300 passing
- [x] `pnpm lint` / `pnpm typecheck` — clean