### PR TITLE
Add opt-in single-connection WebSocket mode

### DIFF
--- a/src/__tests__/websocket-client.test.ts
+++ b/src/__tests__/websocket-client.test.ts
@@ -1,0 +1,113 @@
+import WebSocketClient from '../websocket-client';
+
+jest.mock('reconnecting-websocket', () => {
+  const instances: any[] = [];
+  class MockReconnectingWebSocket {
+    close = jest.fn();
+
+    reconnect = jest.fn();
+
+    send = jest.fn();
+
+    binaryType = '';
+
+    onopen: any = null;
+
+    onmessage: any = null;
+
+    onerror: any = null;
+
+    onclose: any = null;
+
+    readyState = 1;
+
+    OPEN = 1;
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: MockReconnectingWebSocket,
+    instances,
+  };
+});
+
+const { instances } = jest.requireMock('reconnecting-websocket') as { instances: any[] };
+
+const makeClient = (singleConnection: boolean) =>
+  new WebSocketClient({
+    host: 'localhost',
+    token: 'token',
+    version: 2,
+    events: [],
+  }, {
+    singleConnection,
+  });
+
+describe('WebSocketClient single-connection', () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  it('detaches handlers and closes the previous socket before reconnecting when enabled', () => {
+    const client = makeClient(true);
+    client.connect();
+    const previous = instances[0];
+
+    client.connect();
+
+    expect(previous.close).toHaveBeenCalled();
+    expect(previous.onmessage).toBeNull();
+    expect(previous.onopen).toBeNull();
+    expect(previous.onerror).toBeNull();
+    expect(previous.onclose).toBeNull();
+    expect(instances).toHaveLength(2);
+    expect(client.socket).toBe(instances[1]);
+  });
+
+  it('keeps the previous socket untouched when disabled (default behavior)', () => {
+    const client = makeClient(false);
+    client.connect();
+    const previous = instances[0];
+
+    client.connect();
+
+    expect(previous.close).not.toHaveBeenCalled();
+    expect(instances).toHaveLength(2);
+  });
+});
+
+describe('WebSocketClient close', () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  it('detaches inner socket handlers on force close', () => {
+    const client = makeClient(true);
+    client.connect();
+    const socket = instances[0];
+
+    client.close(true);
+
+    expect(socket.close).toHaveBeenCalledWith(1000);
+    expect(socket.onmessage).toBeNull();
+    expect(socket.onopen).toBeNull();
+    expect(socket.onerror).toBeNull();
+    expect(socket.onclose).toBeNull();
+    expect(client.socket).toBeNull();
+  });
+
+  it('leaves inner socket handlers attached on non-force close', () => {
+    const client = makeClient(true);
+    client.connect();
+    const socket = instances[0];
+
+    client.close();
+
+    expect(socket.close).toHaveBeenCalledWith(1000);
+    expect(socket.onmessage).not.toBeNull();
+  });
+});

--- a/src/simple/Websocket.ts
+++ b/src/simple/Websocket.ts
@@ -15,6 +15,12 @@ const logger = IssueReporter.loggerFor('simple-ws-client');
 export class Websocket extends Emitter {
   ws: WazoWebSocketClient | null | undefined;
 
+  // Opt-in (default off). When true, open() closes any previous client before creating a new one,
+  // and connect() closes the previous socket too, so there is only ever one live connection. Keeps
+  // existing consumers (web/desktop) on current behavior; mobile enables it to avoid
+  // duplicate/overlapping sockets that double every event on push-wake.
+  singleConnection = false;
+
   eventLists: string[];
 
   CONFERENCE_USER_PARTICIPANT_JOINED: string;
@@ -42,11 +48,25 @@ export class Websocket extends Emitter {
     this.ws = null;
   }
 
+  enableSingleConnection(value = true) {
+    this.singleConnection = value;
+  }
+
   open(host: string, session: Session) {
     logger.info('open simple WebSocket', {
       host,
       token: obfuscateToken(session.token),
+      singleConnection: this.singleConnection,
     });
+
+    // Opt-in: tear down any previous client first so we never leave an orphaned, still-open socket
+    // emitting events in parallel (which doubles every event delivered to the consumer).
+    if (this.singleConnection && this.ws) {
+      logger.info('single-connection: closing previous WS client before reconnecting');
+      this.ws.close(true);
+      this.ws = null;
+    }
+
     this.ws = new WazoWebSocketClient({
       host,
       token: session.token,
@@ -56,6 +76,7 @@ export class Websocket extends Emitter {
     }, {
       rejectUnauthorized: false,
       binaryType: 'arraybuffer',
+      singleConnection: this.singleConnection,
     });
     this.ws.connect();
     // Re-emit all events

--- a/src/simple/__tests__/Websocket.test.ts
+++ b/src/simple/__tests__/Websocket.test.ts
@@ -1,0 +1,67 @@
+import { Websocket } from '../Websocket';
+
+jest.mock('../../websocket-client', () => {
+  const actual = jest.requireActual('../../websocket-client');
+  const instances: any[] = [];
+
+  class MockWazoWebSocketClient {
+    static readonly eventLists = actual.default.eventLists;
+
+    close = jest.fn();
+
+    connect = jest.fn();
+
+    on = jest.fn();
+
+    updateToken = jest.fn();
+
+    isConnected = jest.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: MockWazoWebSocketClient,
+    instances,
+  };
+});
+
+const { instances } = jest.requireMock('../../websocket-client') as { instances: any[] };
+
+const session = { token: 'token', uuid: 'uuid' } as any;
+
+describe('simple Websocket single-connection', () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  it('closes the previous client with force before reassigning on a second open()', () => {
+    const ws = new Websocket();
+    ws.enableSingleConnection();
+
+    ws.open('localhost', session);
+    const previous = instances[0];
+
+    ws.open('localhost', session);
+
+    expect(previous.close).toHaveBeenCalledWith(true);
+    expect(instances).toHaveLength(2);
+    expect(ws.ws).toBe(instances[1]);
+  });
+
+  it('does not close the previous client when single-connection is disabled', () => {
+    const ws = new Websocket();
+
+    ws.open('localhost', session);
+    const previous = instances[0];
+
+    ws.open('localhost', session);
+
+    expect(previous.close).not.toHaveBeenCalled();
+    expect(instances).toHaveLength(2);
+  });
+});

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -200,7 +200,7 @@ class WebSocketClient extends Emitter {
         this.socket.onclose = null;
         this.socket.close();
       } catch (e) {
-        logger.warn('single-connection: error closing previous socket', e);
+        logger.warn('single-connection: error closing previous socket', { message: (e as Error)?.message });
       }
       this.socket = null;
     }
@@ -300,6 +300,15 @@ class WebSocketClient extends Emitter {
     if (this.socket.readyState === 3) {
       logger.warn('Trying to close an already closed websocket, bailing.', { url: this._getUrl() });
       return;
+    }
+
+    if (force) {
+      // Detach inner socket handlers before closing so the dying socket can't fire one last batch
+      // of events through this Emitter after teardown (mirrors the detach-before-close in connect()).
+      this.socket.onmessage = null;
+      this.socket.onopen = null;
+      this.socket.onerror = null;
+      this.socket.onclose = null;
     }
 
     this.socket.close(1000);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -187,6 +187,24 @@ class WebSocketClient extends Emitter {
       host: this.host,
       token: obfuscateToken(this.token),
     });
+
+    // Opt-in single-connection (this.options.singleConnection): if a socket already exists, detach
+    // its handlers and close it before creating a new one, so the old socket can't keep firing
+    // onmessage in parallel and double every event. Default off → unchanged for existing consumers.
+    if (this.options?.singleConnection && this.socket) {
+      logger.info('single-connection: closing previous socket before reconnecting', { host: this.host });
+      try {
+        this.socket.onmessage = null;
+        this.socket.onopen = null;
+        this.socket.onerror = null;
+        this.socket.onclose = null;
+        this.socket.close();
+      } catch (e) {
+        logger.warn('single-connection: error closing previous socket', e);
+      }
+      this.socket = null;
+    }
+
     this.socket = new ReconnectingWebSocket(this._getUrl.bind(this), [], this.options);
 
     if (this.options.binaryType) {


### PR DESCRIPTION
## Summary of the changes

- Add an opt-in `singleConnection` flag (default off), toggled via `Wazo.Websocket.enableSingleConnection()`.
- When enabled, `Websocket.open()` closes the previous client before creating a new one, and `connect()` closes the previous socket before creating a new `ReconnectingWebSocket`. This prevents a stale/orphaned socket from staying open and delivering every event twice.
- Default off, so existing consumers keep current behavior

## How to test

- With the flag off (default): connect/reconnect behaves exactly as before.
- With `enableSingleConnection()` on: call open()/reconnect twice in a row and confirm only one live socket remains and events are received once.