### PR TITLE
ITEM-369/p-asserted-identity

### DIFF
--- a/src/__tests__/web-rtc-client.test.ts
+++ b/src/__tests__/web-rtc-client.test.ts
@@ -1,6 +1,6 @@
 import { Invitation, SessionState } from 'sip.js/lib/api';
 
-import WebRTCClient from '../web-rtc-client';
+import WebRTCClient, { toAssertedIdentity } from '../web-rtc-client';
 
 jest.mock('sip.js/lib/platform/web/transport');
 jest.mock('sip.js/lib/api/user-agent', () => ({
@@ -539,5 +539,36 @@ describe('changeAudioInputDevice', () => {
         },
       });
     });
+  });
+});
+
+describe('toAssertedIdentity', () => {
+  // Shaped like sip.js's parsed P-Asserted-Identity header (a NameAddrHeader).
+  const makeIdentity = (user: string | undefined, displayName: string) => ({
+    uri: { user },
+    displayName,
+  } as any);
+
+  it('maps display name and number from the parsed header', () => {
+    expect(toAssertedIdentity(makeIdentity('30123', 'Loris MADRID')))
+      .toEqual({ displayName: 'Loris MADRID', number: '30123' });
+  });
+
+  it('falls back to the number as display name when no display name is present', () => {
+    expect(toAssertedIdentity(makeIdentity('30123', '')))
+      .toEqual({ displayName: '30123', number: '30123' });
+  });
+
+  it('omits the number when there is no user part', () => {
+    expect(toAssertedIdentity(makeIdentity(undefined, 'Loris MADRID')))
+      .toEqual({ displayName: 'Loris MADRID', number: undefined });
+  });
+
+  it('returns null when the identity carries neither number nor display name', () => {
+    expect(toAssertedIdentity(makeIdentity(undefined, ''))).toBeNull();
+  });
+
+  it('returns null when there is no identity', () => {
+    expect(toAssertedIdentity(null)).toBeNull();
   });
 });

--- a/src/domain/CallSession.ts
+++ b/src/domain/CallSession.ts
@@ -2,12 +2,13 @@ import { SessionState } from 'sip.js/lib/api/session-state';
 import Call, { RECORDING_STATE, type RecordingStateType } from './Call';
 import newFrom from '../utils/new-from';
 import updateFrom from '../utils/update-from';
-import { WazoSession } from './types';
+import { WazoSession, AssertedIdentity } from './types';
 
 type CallSessionArguments = {
   answered: boolean;
   answerTime?: Date | null | undefined;
   answeredBySystem: boolean;
+  assertedIdentity?: AssertedIdentity;
   call: Call | null | undefined;
   callId: string;
   callerNumber: string;
@@ -70,6 +71,8 @@ export default class CallSession {
 
   diversion?: string[];
 
+  assertedIdentity?: AssertedIdentity;
+
   ringing: boolean;
 
   // Should be computed ?
@@ -123,6 +126,7 @@ export default class CallSession {
     cameraEnabled,
     dialedExtension,
     diversion,
+    assertedIdentity,
     sipCallId,
     sipStatus,
     callerNumber,
@@ -156,6 +160,7 @@ export default class CallSession {
     this.cameraEnabled = cameraEnabled;
     this.dialedExtension = dialedExtension || '';
     this.diversion = diversion;
+    this.assertedIdentity = assertedIdentity || undefined;
     this.call = call;
     this.sipStatus = sipStatus;
     this.autoAnswer = autoAnswer || false;

--- a/src/domain/Phone/WebRTCPhone.ts
+++ b/src/domain/Phone/WebRTCPhone.ts
@@ -8,7 +8,7 @@ import { Inviter, Invitation, Session, SessionDescriptionHandlerOptions } from '
 import { SessionDescriptionHandler } from 'sip.js/lib/platform/web';
 import CallSession from '../CallSession';
 import type { Phone, AvailablePhoneOptions } from './Phone';
-import WebRTCClient from '../../web-rtc-client';
+import WebRTCClient, { toAssertedIdentity } from '../../web-rtc-client';
 import Emitter from '../../utils/Emitter';
 import IssueReporter from '../../service/IssueReporter';
 import { PeerConnection, WazoSession } from '../types';
@@ -1862,6 +1862,7 @@ export default class WebRTCPhone extends Emitter implements Phone {
       recordingState: fromSession ? fromSession.recordingState : RECORDING_STATE.INACTIVE,
       sipSession,
       diversion: sipSession?.diversion,
+      assertedIdentity: toAssertedIdentity(sipSession?.assertedIdentity) || undefined,
       conference: !!fromSession && fromSession.isConference(),
       ...extra,
     });

--- a/src/domain/Phone/__tests__/WebRTCPhone.test.ts
+++ b/src/domain/Phone/__tests__/WebRTCPhone.test.ts
@@ -27,6 +27,13 @@ const createPhone = (client: any) => {
   return phone;
 };
 
+const createCreatableMockClient = (sessions: Record<string, any> = {}) => ({
+  ...createMockClient(sessions),
+  isCallHeld: () => false,
+  hasVideo: () => false,
+  isAudioMuted: () => false,
+});
+
 describe('WebRTCPhone.findSipSession', () => {
   it('should return matching sip session when callSession matches', () => {
     const sipSession = { id: 'session-1' };
@@ -89,13 +96,6 @@ describe('WebRTCPhone.findSipSession', () => {
 describe('WebRTCPhone._createCallSession diversion', () => {
   const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
 
-  const createCreatableMockClient = (sessions: Record<string, any> = {}) => ({
-    ...createMockClient(sessions),
-    isCallHeld: () => false,
-    hasVideo: () => false,
-    isAudioMuted: () => false,
-  });
-
   it('propagates diversion from the sipSession', () => {
     const sipSession = { id: 'session-1', diversion: SAMPLE } as any;
     const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
@@ -112,6 +112,31 @@ describe('WebRTCPhone._createCallSession diversion', () => {
     const cs = phone._createCallSession(sipSession);
 
     expect(cs.diversion).toBeUndefined();
+  });
+});
+
+describe('WebRTCPhone._createCallSession assertedIdentity', () => {
+  // Shaped like sip.js's `Session.assertedIdentity` (a parsed NameAddrHeader).
+  // The URI exposes the user via the public `user` getter and the private
+  // `_normal` one, both of which `_createCallSession` reads.
+  const NAME_ADDR_HEADER = { uri: { user: '30123', _normal: { user: '30123' } }, displayName: 'Loris MADRID' };
+
+  it('maps the asserted identity from the sip.js Session.assertedIdentity getter', () => {
+    const sipSession = { id: 'session-1', assertedIdentity: NAME_ADDR_HEADER } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.assertedIdentity).toEqual({ displayName: 'Loris MADRID', number: '30123' });
+  });
+
+  it('is undefined when the sipSession has no asserted identity', () => {
+    const sipSession = { id: 'session-1' } as any;
+    const phone = createPhone(createCreatableMockClient({ 'session-1': sipSession }));
+
+    const cs = phone._createCallSession(sipSession);
+
+    expect(cs.assertedIdentity).toBeUndefined();
   });
 });
 /* eslint-enable no-underscore-dangle */

--- a/src/domain/__tests__/CallSession.test.ts
+++ b/src/domain/__tests__/CallSession.test.ts
@@ -114,6 +114,32 @@ describe('CallSession domain', () => {
     });
   });
 
+  describe('assertedIdentity field', () => {
+    const SAMPLE = { displayName: 'Loris MADRID', number: '30123' };
+
+    it('is undefined when not provided', () => {
+      const cs = new CallSession({} as any);
+      expect(cs.assertedIdentity).toBeUndefined();
+    });
+
+    it('stores the asserted identity passed to the constructor', () => {
+      const cs = new CallSession({ callId: 'a', assertedIdentity: SAMPLE } as any);
+      expect(cs.assertedIdentity).toEqual(SAMPLE);
+    });
+
+    it('copies assertedIdentity via updateFrom', () => {
+      const cs = new CallSession({ callId: 'a', assertedIdentity: SAMPLE } as any);
+      const next = new CallSession({ callId: 'a' } as any);
+      next.updateFrom(cs);
+      expect(next.assertedIdentity).toEqual(SAMPLE);
+    });
+
+    it('preserves assertedIdentity through JSON serialization', () => {
+      const cs = new CallSession({ callId: 'a', assertedIdentity: SAMPLE } as any);
+      expect(stringify(cs).assertedIdentity).toEqual(SAMPLE);
+    });
+  });
+
   describe('diversion field', () => {
     const SAMPLE = ['"Alice" <sip:1001@wazo.example>;reason=unconditional'];
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -262,6 +262,15 @@ export type PeerConnection = RTCPeerConnection & {
   sfu: any;
 };
 
+// Identity asserted by the network in the SIP P-Asserted-Identity header
+// (RFC 3325). Resolved from the 200 OK (outgoing calls) or the INVITE
+// (incoming calls) so the real callee/caller name can be displayed at call
+// setup instead of waiting for a directory reverse-lookup.
+export type AssertedIdentity = {
+  displayName: string;
+  number?: string;
+};
+
 export type WazoSession = (Invitation | Inviter) & {
   remoteTag?: any;
   callId?: string;

--- a/src/web-rtc-client.ts
+++ b/src/web-rtc-client.ts
@@ -15,6 +15,7 @@ import { UserAgentState } from 'sip.js/lib/api/user-agent-state';
 import { Parser } from 'sip.js/lib/core/messages/parser';
 import { C } from 'sip.js/lib/core/messages/methods/constants';
 import { URI } from 'sip.js/lib/grammar/uri';
+import type { NameAddrHeader } from 'sip.js/lib/grammar/name-addr-header';
 import { UserAgent } from 'sip.js/lib/api/user-agent';
 import { holdModifier, stripVideo } from 'sip.js/lib/platform/web/modifiers/modifiers';
 import { SessionDialog } from 'sip.js/lib/core/dialogs/session-dialog';
@@ -35,7 +36,7 @@ import IssueReporter from './service/IssueReporter';
 import Heartbeat from './utils/Heartbeat';
 import { getVideoDirection, hasAnActiveVideo } from './utils/sdp';
 import { lastIndexOf } from './utils/array';
-import type { MediaConfig, UserAgentConfigOverrides, WebRtcConfig, UserAgentOptions, IncomingResponse, PeerConnection, WazoSession, WazoTransport } from './domain/types';
+import type { MediaConfig, UserAgentConfigOverrides, WebRtcConfig, UserAgentOptions, IncomingResponse, PeerConnection, WazoSession, WazoTransport, AssertedIdentity } from './domain/types';
 
 // We need to replace 0.0.0.0 to 127.0.0.1 in the sdp to avoid MOH during a createOffer.
 export const replaceLocalIpModifier = (description: Record<string, any>) => Promise.resolve({ // description is immutable... so we have to clone it or the `type` attribute won't be returned.
@@ -74,6 +75,30 @@ const ON_MEDIA_CONNECTED = 'onMediaConnected';
 export const events = [REGISTERED, UNREGISTERED, REGISTRATION_FAILED, INVITE];
 export const transportEvents = [CONNECTED, DISCONNECTED, TRANSPORT_ERROR, MESSAGE];
 export class CanceledCallError extends Error {}
+
+// Map sip.js's parsed P-Asserted-Identity header (RFC 3325) into a
+// `{ displayName, number }` pair. sip.js parses the header itself — from the
+// 200 OK on outgoing calls and the INVITE on incoming ones — and exposes the
+// result as `Session.assertedIdentity`. `number` reflects only the addr-spec
+// user part, so it stays dialable and is left undefined when the header has no
+// user part. `displayName` falls back to the number when no display name is
+// present. Returns null when the header was absent or carried neither.
+export const toAssertedIdentity = (
+  identity?: NameAddrHeader | null,
+): AssertedIdentity | null => {
+  if (!identity) {
+    return null;
+  }
+
+  const number = identity.uri?.user || undefined;
+  const displayName = identity.displayName || number;
+
+  if (!displayName) {
+    return null;
+  }
+
+  return { displayName, number };
+};
 
 const MAX_REGISTER_TRIES = 5;
 // setting a 24hr timeout and letting the backend define the actual value


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive call-metadata field with unit tests; no changes to signaling or auth, though displayed identity now depends on sip.js header parsing.
> 
> **Overview**
> Exposes **P-Asserted-Identity** (RFC 3325) from sip.js on **`CallSession`** so clients can show the network-asserted caller/callee name and number at setup, without waiting on directory lookup.
> 
> Adds an **`AssertedIdentity`** type (`displayName`, optional `number`) and exported **`toAssertedIdentity`**, which maps sip.js’s parsed `Session.assertedIdentity` (INVITE / 200 OK) with fallbacks when the display name is missing and `null` when the header is absent or empty. **`WebRTCPhone._createCallSession`** sets **`assertedIdentity`** from the SIP session via that helper (alongside existing **`diversion`** handling). **`CallSession`** stores the field through construction, **`updateFrom`**, and JSON serialization. Unit tests cover the mapper, phone wiring, and domain model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87496e0ac9905ddc3c49a705a90fec2fba65df08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->